### PR TITLE
Fix commits and emails exports

### DIFF
--- a/codeface_extraction/commits.py
+++ b/codeface_extraction/commits.py
@@ -8,7 +8,7 @@ from os.path import join as pathjoin
 
 def __select_commits(dbm, project, tagging):
     dbm.doExec("""
-                    SELECT c.id, c.authorDate, a.name,  a.email1, c.commitHash,
+                    SELECT c.id, c.authorDate, a.name, a.email1, c.commitHash,
                            c.ChangedFiles, c.AddedLines, c.DeletedLines, c.DiffSize,
                            cd.file, cd.entityId, cd.entityType, cd.size
 
@@ -56,10 +56,10 @@ def get_list_of_commits(dbm, project, tagging, project_resdir):
     commits = __select_commits(dbm, project, tagging)
 
     # convert commits to tuples
-    lines = ["{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}\n".format(commitId, authorDate, name, 
-                           ChangedFiles, AddedLines, DeletedLines, DiffSize, 
-                           file, entityId, entityType, size ) for commitId, authorDate, name, 
-                           ChangedFiles, AddedLines, DeletedLines, DiffSize, 
+    lines = ["{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}\n".format(commitId, authorDate, name,
+                           email1, commitHash, ChangedFiles, AddedLines, DeletedLines, DiffSize,
+                           file, entityId, entityType, size) for commitId, authorDate, name,
+                           email1, commitHash, ChangedFiles, AddedLines, DeletedLines, DiffSize,
                            file, entityId, entityType, size in commits]
 
     # write lines to file

--- a/codeface_extraction/emails.py
+++ b/codeface_extraction/emails.py
@@ -50,7 +50,8 @@ def get_list_of_emails(dbm, project, tagging, project_resdir):
     emails = __select_emails(dbm, project, tagging)
 
     # convert emails to tuples
-    lines = ["{}; {}; {}\n".format(authorName, creationDate, threadId ) for authorName, creationDate, threadId in emails]
+    lines = ["{}; {}; {}; {}; {}\n".format(authorName, email1, creationDate, subject, threadId ) 
+                                       for authorName, email1, creationDate, subject, threadId in emails]
 
     # write lines to file
     outfile = pathjoin(project_resdir, "emails.list")


### PR DESCRIPTION
Fix for commit cab6990b611679319ae89bdc6336cdc214b01abd , which extended just the SQL statements, but not the respective lists

Signed-off-by: Thomas Bock bockthom@fim.uni-passau.de
