### PR TITLE
Add an extraction of commit messages

### DIFF
--- a/codeface_extraction/codeface_extraction.py
+++ b/codeface_extraction/codeface_extraction.py
@@ -58,28 +58,31 @@ def run_extraction(conf, resdir, extract_commit_messages, extract_impl, extract_
     for extraction in __extractions_project:
         extraction.run()
 
-    # check if list of revisions in database is the same as in the config file
-    revs = conf["revisions"]
-    list_of_revisions = extractions.RevisionExtraction(dbm, conf, resdir, csv_writer).get_list()
-    if revs:
-        if set(revs) != set(list_of_revisions):
-            log.error("List of revisions in configuration file do not match the list stored in the DB! Stopping now.")
-            sys.exit(1)
+    # run range-level extractions (only if explicitely enabled)
+    if extract_on_range_level:
+
+        # check if list of revisions in database is the same as in the config file
+        revs = conf["revisions"]
+        list_of_revisions = extractions.RevisionExtraction(dbm, conf, resdir, csv_writer).get_list()
+        if revs:
+            if set(revs) != set(list_of_revisions):
+                log.error("List of revisions in configuration file do not match the list stored in the DB! Stopping now.")
+                sys.exit(1)
+            else:
+                log.info("List of revisions in configuration file and DB match.")
         else:
-            log.info("List of revisions in configuration file and DB match.")
-    else:
-        log.info("No list of revisions found in configuration file, using the list from the DB instead!")
-        revs = list_of_revisions  # set list of revisions as stored in the database
+            log.info("No list of revisions found in configuration file, using the list from the DB instead!")
+            revs = list_of_revisions  # set list of revisions as stored in the database
 
-    # for all revisions of this project
-    for i in range(len(revs) - 1):
-        start_rev = revs[i]
-        end_rev = revs[i + 1]
+        # for all revisions of this project
+        for i in range(len(revs) - 1):
+            start_rev = revs[i]
+            end_rev = revs[i + 1]
 
-        log.info("%s: Extracting data for version '%s'" % (conf["project"], end_rev))
+            log.info("%s: Extracting data for version '%s'" % (conf["project"], end_rev))
 
-        for extraction in __extractions_range:
-            extraction.run(start_rev, end_rev)
+            for extraction in __extractions_range:
+                extraction.run(start_rev, end_rev)
 
     log.info("Extraction complete!")
 

--- a/codeface_extraction/codeface_extraction.py
+++ b/codeface_extraction/codeface_extraction.py
@@ -13,7 +13,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright 2015-2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
-# Copyright 2016 by Thomas Bock <bockthom@fim.uni-passau.de>
+# Copyright 2016, 2018 by Thomas Bock <bockthom@fim.uni-passau.de>
 # Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
 # All Rights Reserved.
 """
@@ -36,7 +36,7 @@ from csv_writer import csv_writer
 # RUN FOR ALL PROJECTS
 ##
 
-def run_extraction(conf, resdir, extract_impl, extract_on_range_level):
+def run_extraction(conf, resdir, extract_commit_messages, extract_impl, extract_on_range_level):
     """
     Runs the extraction process for the list of given parameters.
 
@@ -50,7 +50,9 @@ def run_extraction(conf, resdir, extract_impl, extract_on_range_level):
     dbm = DBManager(conf)
 
     # get all types of extractions, both project-level and range-level
-    __extractions_project, __extractions_range = extractions.get_extractions(dbm, conf, resdir, csv_writer, extract_impl, extract_on_range_level)
+    __extractions_project, __extractions_range = extractions.get_extractions(dbm, conf, resdir, csv_writer,
+                                                                             extract_commit_messages, extract_impl,
+                                                                             extract_on_range_level)
 
     # run project-level extractions
     for extraction in __extractions_project:
@@ -93,6 +95,8 @@ def get_parser():
                             default='codeface.conf')
     run_parser.add_argument('-p', '--project', help="Project configuration file",
                             required=True)
+    run_parser.add_argument('-m', '--commit-messages', help="Enable extraction of the commit messages",
+                            action='store_true')
     run_parser.add_argument('-i', '--implementation', help="Enable extraction of the source code of functions",
                             action='store_true')
     run_parser.add_argument('-r', '--range', help="Enable extraction of the data on range level",
@@ -112,13 +116,14 @@ def run():
     # - First make all the args absolute
     __resdir = abspath(args.resdir)
     __codeface_conf, __project_conf = map(abspath, (args.config, args.project))
+    __extract_commit_messages = args.commit_messages
     __extract_impl = args.implementation
     __extract_on_range_level = args.range
 
     # load configuration
     __conf = Configuration.load(__codeface_conf, __project_conf)
 
-    run_extraction(__conf, __resdir, __extract_impl, __extract_on_range_level)
+    run_extraction(__conf, __resdir, __extract_commit_messages, __extract_impl, __extract_on_range_level)
 
 
 if __name__ == '__main__':

--- a/codeface_extraction/extractions.py
+++ b/codeface_extraction/extractions.py
@@ -301,6 +301,11 @@ class CommitMessageExtraction(Extraction):
                     ORDER BY c.authorDate
                 """
 
+    def _reduce_result(self, result):
+        # remove problematic characters from description column
+        return [(commitId, commitHash, remove_problematic_characters(description))
+                for (commitId, commitHash, description) in result]
+
 
 # Extraction of function implementations
 class FunctionImplementationExtraction(Extraction):
@@ -505,6 +510,11 @@ class CommitMessageRangeExtraction(Extraction):
 
                     ORDER BY c.authorDate
                 """
+
+    def _reduce_result(self, result):
+        # remove problematic characters from description column
+        return [(commitId, commitHash, remove_problematic_characters(description))
+                for (commitId, commitHash, description) in result]
 
 
 class EmailRangeExtraction(Extraction):

--- a/codeface_extraction/extractions.py
+++ b/codeface_extraction/extractions.py
@@ -35,14 +35,21 @@ from codeface.cli import log
 #
 
 
-def get_extractions(dbm, conf, resdir, csv_writer, extract_impl, extract_on_range_level):
+def get_extractions(dbm, conf, resdir, csv_writer, extract_commit_messages, extract_impl, extract_on_range_level):
     # all extractions are sublcasses of Extraction:
     # instantiate them all!
     __extractions = []
     for cls in Extraction.__subclasses__():
-        if (extract_impl or
-                (str(cls) != "<class 'codeface_extraction.extractions.FunctionImplementationExtraction'>" and
-                 str(cls) != "<class 'codeface_extraction.extractions.FunctionImplementationRangeExtraction'>")):
+        if ((extract_impl and
+                (str(cls) == "<class 'codeface_extraction.extractions.FunctionImplementationExtraction'>" or
+                 str(cls) == "<class 'codeface_extraction.extractions.FunctionImplementationRangeExtraction'>")) or
+            (extract_commit_messages and
+                (str(cls) == "<class 'codeface_extraction.extractions.CommitMessageExtraction'>" or
+                 str(cls) == "<class 'codeface_extraction.extractions.CommitMessageRangeExtraction'>")) or
+            (str(cls) != "<class 'codeface_extraction.extractions.FunctionImplementationExtraction'>" and
+             str(cls) != "<class 'codeface_extraction.extractions.FunctionImplementationRangeExtraction'>" and
+             str(cls) != "<class 'codeface_extraction.extractions.CommitMessageExtraction'>" and
+             str(cls) != "<class 'codeface_extraction.extractions.CommitMessageRangeExtraction'>")):
             __extractions.append(cls(dbm, conf, resdir, csv_writer))
 
     # group extractions by "project-levelness"

--- a/codeface_extraction/extractions.py
+++ b/codeface_extraction/extractions.py
@@ -302,8 +302,8 @@ class CommitMessageExtraction(Extraction):
                 """
 
     def _reduce_result(self, result):
-        # remove problematic characters from description column
-        return [(commitId, commitHash, remove_problematic_characters(description))
+        # fix character encoding and remove problematic characters from description column
+        return [(commitId, commitHash, fix_characters_in_string(description))
                 for (commitId, commitHash, description) in result]
 
 
@@ -336,8 +336,8 @@ class FunctionImplementationExtraction(Extraction):
                 """
 
     def _reduce_result(self, result):
-        # remove problematic characters from implementation column
-        return [(commitId, commitHash, fileId, entityId, remove_problematic_characters(impl))
+        # fix character encoding and remove problematic characters from implementation column
+        return [(commitId, commitHash, fileId, entityId, fix_characters_in_string(impl))
                 for (commitId, commitHash, fileId, entityId, impl) in result]
 
 
@@ -512,8 +512,8 @@ class CommitMessageRangeExtraction(Extraction):
                 """
 
     def _reduce_result(self, result):
-        # remove problematic characters from description column
-        return [(commitId, commitHash, remove_problematic_characters(description))
+        # fix character encoding and remove problematic characters from description column
+        return [(commitId, commitHash, fix_characters_in_string(description))
                 for (commitId, commitHash, description) in result]
 
 
@@ -595,8 +595,8 @@ class FunctionImplementationRangeExtraction(Extraction):
                 """
 
     def _reduce_result(self, result):
-        # remove problematic characters from implementation column
-        return [(commitId, commitHash, fileId, entityId, remove_problematic_characters(impl))
+        # fix character encoding and remove problematic characters from implementation column
+        return [(commitId, commitHash, fileId, entityId, fix_characters_in_string(impl))
                 for (commitId, commitHash, fileId, entityId, impl) in result]
 
 
@@ -604,7 +604,7 @@ class FunctionImplementationRangeExtraction(Extraction):
 # HELPER FUNCTIONS
 #
 
-def remove_problematic_characters(text):
+def fix_characters_in_string(text):
     """
     Removes control characters such as \r\n \x1b \ufffd from string impl and returns a unicode
     string where all control characters have been replaced by a space.

--- a/codeface_extraction/extractions.py
+++ b/codeface_extraction/extractions.py
@@ -36,20 +36,22 @@ from codeface.cli import log
 
 
 def get_extractions(dbm, conf, resdir, csv_writer, extract_commit_messages, extract_impl, extract_on_range_level):
-    # all extractions are sublcasses of Extraction:
+    # all extractions are subclasses of Extraction:
     # instantiate them all!
     __extractions = []
+
+    # check which extractions to skip
+    extractions_to_skip = []
+    if not extract_commit_messages:
+        extractions_to_skip += ["<class 'codeface_extraction.extractions.CommitMessageExtraction'>"]
+        extractions_to_skip += ["<class 'codeface_extraction.extractions.CommitMessageRangeExtraction'>"]
+    if not extract_impl:
+        extractions_to_skip += ["<class 'codeface_extraction.extractions.FunctionImplementationExtraction'>"]
+        extractions_to_skip += ["<class 'codeface_extraction.extractions.FunctionImplementationRangeExtraction'>"]
+
+    # collect all extractions (except for the ones to skip) and instantiate objects
     for cls in Extraction.__subclasses__():
-        if ((extract_impl and
-                (str(cls) == "<class 'codeface_extraction.extractions.FunctionImplementationExtraction'>" or
-                 str(cls) == "<class 'codeface_extraction.extractions.FunctionImplementationRangeExtraction'>")) or
-            (extract_commit_messages and
-                (str(cls) == "<class 'codeface_extraction.extractions.CommitMessageExtraction'>" or
-                 str(cls) == "<class 'codeface_extraction.extractions.CommitMessageRangeExtraction'>")) or
-            (str(cls) != "<class 'codeface_extraction.extractions.FunctionImplementationExtraction'>" and
-             str(cls) != "<class 'codeface_extraction.extractions.FunctionImplementationRangeExtraction'>" and
-             str(cls) != "<class 'codeface_extraction.extractions.CommitMessageExtraction'>" and
-             str(cls) != "<class 'codeface_extraction.extractions.CommitMessageRangeExtraction'>")):
+        if (str(cls) not in extractions_to_skip):
             __extractions.append(cls(dbm, conf, resdir, csv_writer))
 
     # group extractions by "project-levelness"


### PR DESCRIPTION
Extract the commit messages from the database together with the corresponding commit hash into a separate file.
The commit-message extraction is implemented for both project level and range level.
To use the commit-message extraction, an additional command-line option "-m" or "--commit-messages" is added.

In addition, don't print log statements regarding range-level extractions when no range-level extractions are performed.
