### PR TITLE
Adjust GitHub and Jira extraction to a consistent format

### DIFF
--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -131,12 +131,12 @@ def reformat(issue_data):
 
     # known resolutions from JIRA and GitHub default labels
     known_resolutions = {"unresolved", "fixed", "wontfix", "duplicate", "invalid", "incomplete",
-                               "cannot reproduce", "later", "not a problem", "implemented", "done",
-                               "auto closed",
-                               "pending", "closed", "remind", "resolved", "not a bug", "workaround",
-                               "staged",
-                               "delivered", "information provided", "works for me", "feedback received",
-                               "wontdo"}
+                         "cannot reproduce", "later", "not a problem", "implemented", "done",
+                         "auto closed",
+                         "pending", "closed", "remind", "resolved", "not a bug", "workaround",
+                         "staged",
+                         "delivered", "information provided", "works for me", "feedback received",
+                         "wontdo"}
 
     # re-process all issues
     for issue in issue_data:
@@ -259,15 +259,15 @@ def reformat(issue_data):
             # formats the event according to it's event type
             if event["event"] == "closed":
                 event["event"] = "state_updated"
-                event["event_info_1"] = "closed"
-                event["event_info_2"] = "open"
+                event["event_info_1"] = "closed"  # new state
+                event["event_info_2"] = "open"  # old state
                 # creates new state change object
                 state_changes.append([event['created_at'], "closed"])
 
             elif event["event"] == "reopened":
                 event["event"] = "state_updated"
-                event["event_info_1"] = "open"
-                event["event_info_2"] = "closed"
+                event["event_info_1"] = "open"  # new state
+                event["event_info_2"] = "closed"  # old state
                 # creates new resolution change object
                 state_changes.append([event['created_at'], "open"])
 
@@ -324,7 +324,7 @@ def reformat(issue_data):
         state_changes.sort(key=lambda x: x[0])
         resolution_changes.sort(key=lambda x: x[0])
 
-        # add event name to comment and add reference target
+        # the format of every comment is adjusted to the event format
         for comment in issue["commentsList"]:
             comment["event"] = "commented"
             comment["ref_target"] = ""
@@ -419,7 +419,6 @@ def insert_user_data(issues, conf):
         # check database for event authors
         for event in issue["eventsList"]:
             # get the event user from the DB
-
             event["user"] = get_or_update_user(event["user"])
             # get the reference-target user from the DB if needed
             if event["ref_target"] != "":

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -483,6 +483,7 @@ def print_to_disk_new(issues, results_folder):
         for event in issue["eventsList"]:
             lines.append((
                 issue["number"],
+                issue["title"],
                 issue["type"],
                 issue["state_new"],
                 issue["resolution"],

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -114,15 +114,17 @@ def format_time(time):
     """
 
     # empty time would be formatted to current date
-    if time != "":
+    if time == "" or time is None:
+        return ""
+    else:
         d = dateparser.parse(time)
-        time = d.strftime("%Y-%m-%d %H:%M:%S")
-    return time
+        return d.strftime("%Y-%m-%d %H:%M:%S")
 
 
 def create_user(name, username, email):
     """
     Creates an user object with all needed information
+
     :param name: the name the user shall have
     :param username: the username the user shall have
     :param email:  the email the user shall have

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -15,6 +15,7 @@
 # Copyright 2017 by Raphael Nömmer <noemmer@fim.uni-passau.de>
 # Copyright 2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 # Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
+# Copyright 2018 by Anselm Fehnker <fehnker@fim.uni-passau.de>
 # All Rights Reserved.
 """
 This file is able to extract Github issue data from json files.
@@ -26,7 +27,9 @@ import json
 import os
 import sys
 import urllib
+from datetime import datetime
 
+import operator
 from codeface.cli import log
 from codeface.cluster.idManager import idManager
 from codeface.configuration import Configuration
@@ -62,6 +65,7 @@ def run():
     issues = insert_user_data(issues, __conf)
     # 4) dump result to disk
     print_to_disk(issues, __resdir)
+    print_to_disk_new(issues, __resdir)
 
     log.info("Github issue processing complete!")
 
@@ -96,28 +100,149 @@ def reformat(issue_data):
 
     log.devinfo("Re-arranging Github issues...")
 
+    def format_time(time):
+        """Tries to format times from different sources to a consistent time format
+
+        :param time: the time that shall be formatted
+        :return: the formatted time
+        """
+
+        try:
+            # format from new GitHub-Wrapper files
+            d = datetime.strptime(time, '%Y-%m-%dT%H:%M:%SZ')
+            return d.strftime('%Y-%m-%d %H:%M:%S')
+        except ValueError:
+            # format from new GitHub-Wrapper files with no seconds
+            try:
+                d = datetime.strptime(time, '%Y-%m-%dT%H:%MZ')
+                return d.strftime('%Y-%m-%d %H:%M:%S')
+            except ValueError:
+                try:
+                    # format of relatedCommits time
+                    d = datetime.strptime(time, '%Y-%m-%dT%H:%M:%S+%f:00')
+                    return d.strftime('%Y-%m-%d %H:%M:%S')
+                except ValueError:
+                    # if the given time format is not know it can't be formatted, so it just gets returned
+                    # also happens if the time already has the correct format (old GitHub-Wrapper files)
+                    return time
+
+    # known types from JIRA and GitHub default labels
+    known_types = {"bug", "improvement", "enhancement", "new feature", "task", "test", "wish"}
+
+    # known resolutions from JIRA and GitHub default labels
+    known_resolutions = {"unresolved", "fixed", "wontfix", "duplicate", "invalid", "incomplete",
+                               "cannot reproduce", "later", "not a problem", "implemented", "done",
+                               "auto closed",
+                               "pending", "closed", "remind", "resolved", "not a bug", "workaround",
+                               "staged",
+                               "delivered", "information provided", "works for me", "feedback received",
+                               "wontdo"}
+
     # re-process all issues
     for issue in issue_data:
         # temporary container for references
         comments = dict()
 
-        # initialize event
+        # empty container for issue types
+        issue["type"] = []
+
+        # empty container for issue resolutions
+        issue["resolution"] = []
+
+        # if an issue has no eventsList an empty Lists gets created
+        if issue['eventsList'] is None:
+            issue['eventsList'] = []
+
+        # if an issue has no commentsList an empty Lists gets created
+        if issue["commentsList"] is None:
+            issue["commentsList"] = []
+
+        # if an issue has no relatedCommits an empty Lists gets created
+        if issue["relatedCommits"] is None:
+            issue["relatedCommits"] = []
+
+        # if an issue has no relatedIssues an empty Lists gets created
+        if "relatedIssues" not in issue:
+            issue["relatedIssues"] = []
+
+        # add 'closed_at' information if not present yet
+        if issue["closed_at"] is None:
+            issue["closed_at"] = ""
+
+        # parses the creation time in the correct format
+        issue['created_at'] = format_time(issue['created_at'])
+
+        # parses the close time in the correct format
+        issue['closed_at'] = format_time(issue['closed_at'])
+
+        # checks if the issue is a pull-request or a normal issue and adapts the type
+        if issue["isPullRequest"]:
+            issue["type"].append("pull request")
+        else:
+            issue["type"].append("issue")
+
+        # brings the state to lowercase. Is needed for consistency reasons in the new file format
+        issue["state_new"] = issue["state"].lower()
+
+        # adds the issue creation time with the default state to an list
+        # list is needed to find out the state the issue had when a comment was written
+        state_changes = [[issue['created_at'], "open"]]
+
+        # adds the issue creation time with the default resolution to an list
+        # list is needed to find out the resolutions the issue had when a comment was written
+        resolution_changes = [[issue['created_at'], []]]
+
+        # adds creation event to eventsList
         created_event = dict()
         created_event["user"] = issue["user"]
         created_event["created_at"] = issue["created_at"]
         created_event["event"] = "created"
+        created_event["event_info_1"] = "open"
+        created_event["event_info_2"] = []
         issue["eventsList"].append(created_event)
 
-        # add event name to comment and add reference target
-        for comment in issue["commentsList"]:
-            comment["event"] = "commented"
-            comment["ref_target"] = ""
-            # cache comment by date to resolve/re-arrange references later
-            comments[comment["created_at"]] = comment
+        # adds events for related issues to eventsList
+        # GH-Wrapper doesn't provide information about time and user yet. Has to be updated if this changes
+        for rel_issue in issue["relatedIssues"]:
+            link_event = dict()
+            author = dict()
+            author["username"] = ""
+            author["name"] = ""
+            author["email"] = ""
+            link_event["user"] = author
+            link_event["created_at"] = ""
+            link_event["event"] = "add_link"
+            link_event["event_info_1"] = rel_issue
+            link_event["event_info_2"] = "issue"
+            link_event["ref_target"] = ""
+            issue["eventsList"].append(link_event)
 
-        # add reference target to events
+        # adds events for related commits to eventsList
+        for rel_commit in issue["relatedCommits"]:
+            link_event = dict()
+            link_event["created_at"] = rel_commit["time"]
+            link_event["event"] = "add_link"
+            link_event["event_info_1"] = rel_commit["hash"]
+            link_event["event_info_2"] = "commit"
+            link_event["ref_target"] = ""
+
+            # old gh-wrapper data has just a unicode string as an author. new gh-wrapper data has an author object
+            # for old data an author object is created
+            if isinstance(rel_commit["author"], unicode):
+                author = dict()
+                author["username"] = rel_commit["author"]
+                author["name"] = rel_commit["author"]
+                author["email"] = ""
+                link_event["user"] = author
+            else:
+                link_event["user"] = rel_commit["author"]
+
+            issue["eventsList"].append(link_event)
+
+        # updates format of every event in the eventsList of an issue
         for event in issue["eventsList"]:
             event["ref_target"] = ""
+
             # if event collides with a comment
             if event["created_at"] in comments:
                 comment = comments[event["created_at"]]
@@ -128,16 +253,106 @@ def reformat(issue_data):
                     event["ref_target"] = event["user"]
                     event["user"] = comment["user"]
 
+            # parses the event time in the correct format
+            event["created_at"] = format_time(event["created_at"])
+
+            # formats the event according to it's event type
+            if event["event"] == "closed":
+                event["event"] = "state_updated"
+                event["event_info_1"] = "closed"
+                event["event_info_2"] = "open"
+                # creates new state change object
+                state_changes.append([event['created_at'], "closed"])
+
+            elif event["event"] == "reopened":
+                event["event"] = "state_updated"
+                event["event_info_1"] = "open"
+                event["event_info_2"] = "closed"
+                # creates new resolution change object
+                state_changes.append([event['created_at'], "open"])
+
+            elif event["event"] == "labeled":
+                label = event["label"]["name"].lower()
+                event["event_info_1"] = label
+
+                # if the label is in this list, it also is a type of the issue
+                if label in known_types:
+                    issue["type"].append(str(label))
+
+                    # creates an event for type updates and adds it to the eventsList
+                    type_event = dict()
+                    type_event["user"] = issue["user"]
+                    type_event["created_at"] = event["created_at"]
+                    type_event["event"] = "type_updated"
+                    type_event["event_info_1"] = label
+                    type_event["event_info_2"] = ""
+                    type_event["ref_target"] = ""
+                    issue["eventsList"].append(type_event)
+
+                # if the label is in this list, it also is a resolution of the issue
+                elif label in known_resolutions:
+                    issue["resolution"].append(str(label))
+
+                    # creates an event for resolution updates and adds it to the eventsList
+                    resolution_event = dict()
+                    resolution_event["user"] = issue["user"]
+                    resolution_event["created_at"] = event["created_at"]
+                    resolution_event["event"] = "resolution_updated"
+                    resolution_event["event_info_1"] = label
+                    resolution_event["event_info_2"] = ""
+                    resolution_event["ref_target"] = ""
+                    issue["eventsList"].append(resolution_event)
+
+                    # the added resolution is appended to the old resolution list
+                    # works because label events are sorted by time
+                    new_resolutions = list(resolution_changes[-1][1])
+                    new_resolutions.append(str(label))
+                    # creates new resolution change object
+                    resolution_changes.append([resolution_event["created_at"], new_resolutions])
+
+            # %TODO: event for removed labels has to be checked. Data is missing
+
+            # if event_info_1 does not exist in the event, an empty info is created
+            if "event_info_1" not in event:
+                event["event_info_1"] = ""
+
+            # if event_info_2 does not exist in the event, an empty info is created
+            if 'event_info_2' not in event:
+                event["event_info_2"] = ""
+
+        # state and resolution change lists get sorted by time
+        state_changes.sort(key=lambda x: x[0])
+        resolution_changes.sort(key=lambda x: x[0])
+
+        # add event name to comment and add reference target
+        for comment in issue["commentsList"]:
+            comment["event"] = "commented"
+            comment["ref_target"] = ""
+
+            comment["created_at"] = format_time(comment["created_at"])
+
+            # cache comment by date to resolve/re-arrange references later
+            comments[comment["created_at"]] = comment
+
+            # the state the issue had when the comment was written is searched out
+            for state in state_changes:
+                if comment['created_at'] > state[0]:
+                    comment['event_info_1'] = state[1]
+
+            # the resolution the issue had when the comment was written is searched out
+            for resolution in resolution_changes:
+                if comment['created_at'] > resolution[0]:
+                    comment['event_info_2'] = resolution[1]
+
         # merge events and comment lists
         issue["eventsList"] = issue["commentsList"] + issue["eventsList"]
-
-        # add 'closed_at' information if not present yet
-        if issue["closed_at"] is None:
-            issue["closed_at"] = ""
 
         # remove events without user
         issue["eventsList"] = [event for event in issue["eventsList"] if
                                not (event["user"] is None or event["ref_target"] is None)]
+
+        # sorts eventsList by time
+        issue["eventsList"].sort(key=operator.itemgetter('created_at'))
 
     return issue_data
 
@@ -204,16 +419,21 @@ def insert_user_data(issues, conf):
         # check database for event authors
         for event in issue["eventsList"]:
             # get the event user from the DB
+
             event["user"] = get_or_update_user(event["user"])
             # get the reference-target user from the DB if needed
             if event["ref_target"] != "":
                 event["ref_target"] = get_or_update_user(event["ref_target"])
+                event["event_info_1"] = event["ref_target"]["name"]
+                event["event_info_2"] = event["ref_target"]["email"]
 
     return issues
 
 
 def print_to_disk(issues, results_folder):
-    """Print issues to file 'issues.list' in result folder
+    """Print issues to file 'issues.list' in result folder.
+    This format is outdated but still used by the network library.
+    When the network library is updated, this method can be overwritten by 'print_to_disk_new'.
 
     :param issues: the issues to dump
     :param results_folder: the folder where to place 'issues.list' output file
@@ -238,6 +458,43 @@ def print_to_disk(issues, results_folder):
                 event["created_at"],
                 "" if event["ref_target"] == "" else event["ref_target"]["name"],
                 event["event"]
+            ))
+
+    # write to output file
+    csv_writer.write_to_csv(output_file, lines)
+
+
+def print_to_disk_new(issues, results_folder):
+    """Print issues to file 'issues_new.list' in result folder.
+    This file has a consistent format to the 'bugs-jira.list' file.
+    When the network library is updated, this is the format which shall be used.
+
+    :param issues: the issues to dump
+    :param results_folder: the folder where to place 'issues.list' output file
+    """
+
+    # construct path to output file
+    output_file = os.path.join(results_folder, "issues_new.list")
+    log.info("Dumping output in file '{}'...".format(output_file))
+
+    # construct lines of output
+    lines = []
+    for issue in issues:
+        for event in issue["eventsList"]:
+            lines.append((
+                issue["number"],
+                issue["type"],
+                issue["state_new"],
+                issue["resolution"],
+                issue["created_at"],
+                issue["closed_at"],
+                [],  # components
+                event["event"],
+                event["user"]["name"],
+                event["user"]["email"],
+                event["created_at"],
+                event["event_info_1"],
+                event["event_info_2"]
             ))
 
     # write to output file

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -131,6 +131,13 @@ def create_user(name, username, email):
     :return: the created user object
     """
 
+    if name is None:
+        name = ""
+    if username is None:
+        username = ""
+    if email is None:
+        email = ""
+
     user = dict()
     user["name"] = name
     user["username"] = username

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -240,7 +240,7 @@ def merge_issue_events(issue_data):
             if rel_commit["referenced_at"] is None:
                 rel_commit["user"] = create_user("", "", "")
                 rel_commit["created_at"] = ""
-                rel_commit["event"] = "hasCommit"
+                rel_commit["event"] = "has_commit"
                 rel_commit["event_info_1"] = rel_commit["commit_id"]
                 rel_commit["event_info_2"] = ""
                 rel_commit["ref_target"] = ""
@@ -399,7 +399,8 @@ def reformat_events(issue_data):
 
 
 def insert_user_data(issues, conf):
-    """Insert user data into database ad update issue data.
+    """
+    Insert user data into database ad update issue data.
 
     :param issues: the issues to retrieve user data from
     :param conf: the project configuration
@@ -443,9 +444,9 @@ def insert_user_data(issues, conf):
 
         # update user data with person information from DB
         person = idservice.getPersonFromDB(idx)
-        user["email"] = person["email1"]  # column 'email1'
-        user["name"] = person["name"]  # column 'name'
-        user["id"] = person["id"]  # column 'id'
+        user["email"] = person["email1"]  # column "email1"
+        user["name"] = person["name"]  # column "name"
+        user["id"] = person["id"]  # column "id"
 
         # add user information to buffer
         # user_string = get_user_string(user["name"], user["email"]) # update for
@@ -473,12 +474,12 @@ def insert_user_data(issues, conf):
 
 def print_to_disk(issues, results_folder):
     """
-    Print issues to file 'issues.list' in result folder.
+    Print issues to file "issues.list" in result folder.
     This format is outdated but still used by the network library.
-    TODO When the network library is updated, this method can be overwritten by 'print_to_disk_new'.
+    TODO When the network library is updated, this method can be overwritten by "print_to_disk_new".
 
     :param issues: the issues to dump
-    :param results_folder: the folder where to place 'issues.list' output file
+    :param results_folder: the folder where to place "issues.list" output file
     """
 
     # construct path to output file
@@ -508,12 +509,12 @@ def print_to_disk(issues, results_folder):
 
 def print_to_disk_new(issues, results_folder):
     """
-    Print issues to file 'issues_new.list' in result folder.
-    This file has a consistent format to the 'bugs-jira.list' file.
+    Print issues to file "issues_new.list" in result folder.
+    This file has a consistent format to the "bugs-jira.list" file.
     TODO When the network library is updated, this is the format which shall be used.
 
     :param issues: the issues to dump
-    :param results_folder: the folder where to place 'issues.list' output file
+    :param results_folder: the folder where to place "issues.list" output file
     """
 
     # construct path to output file

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -545,9 +545,10 @@ def print_to_disk(issues, results_folder):
 
 
 def print_to_disk_bugs(issues, results_folder):
-    """Sorts of bug issues and prints them to file 'bugs-jira.list' in result folder
-    This method prints in a new format which is consistent to the new GitHub format.
-    When the network library is updated this format shall be used in all print to disk methods.
+    """
+    Sorts of bug issues and prints them to file 'bugs-jira.list' in result folder
+    This method prints in a new format which is consistent to the format of 'print_to_disk_new' in 'issue_processing.py'.
+    TODO When the network library is updated this format shall be used in all print to disk methods.
 
     :param issues: the issues to sort of bugs
     :param results_folder: the folder where to place 'bugs-jira.list' output file

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -128,15 +128,17 @@ def format_time(time):
     """
 
     # empty time would be formatted to current date
-    if time != "":
+    if time == "" or time is None:
+        return ""
+    else:
         d = dateparser.parse(time)
-        time = d.strftime("%Y-%m-%d %H:%M:%S")
-    return time
+        return d.strftime("%Y-%m-%d %H:%M:%S")
 
 
 def create_user(name, username, email):
     """
     Creates an user object with all needed information
+
     :param name: the name the user shall have
     :param username: the username the user shall have
     :param email:  the email the user shall have

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -41,19 +41,19 @@ from csv_writer import csv_writer
 from jira import JIRA
 
 reload(sys)
-sys.setdefaultencoding('utf-8')
+sys.setdefaultencoding("utf-8")
 
 
 def run():
     # get all needed paths and argument for the method call.
-    parser = argparse.ArgumentParser(prog='codeface', description='Codeface extraction')
-    parser.add_argument('-c', '--config', help="Codeface configuration file", default='codeface.conf')
-    parser.add_argument('-p', '--project', help="Project configuration file", required=True)
-    parser.add_argument('resdir', help="Directory to store analysis results in")
-    parser.add_argument('-s', '--skip_history',
+    parser = argparse.ArgumentParser(prog="codeface", description="Codeface extraction")
+    parser.add_argument("-c", "--config", help="Codeface configuration file", default="codeface.conf")
+    parser.add_argument("-p", "--project", help="Project configuration file", required=True)
+    parser.add_argument("resdir", help="Directory to store analysis results in")
+    parser.add_argument("-s", "--skip_history",
                         help="Skip methods that retrieve additional history information from the configured JIRA" +
                              "server. This decreases the runtime and shuts off the external connection",
-                        action='store_true')
+                        action="store_true")
 
     # parse arguments
     args = parser.parse_args(sys.argv[1:])
@@ -63,12 +63,12 @@ def run():
     __conf = Configuration.load(__codeface_conf, __project_conf)
 
     # get source and results folders
-    __srcdir = os.path.abspath(os.path.join(args.resdir, __conf['repo'] + "_proximity", "conway", "issues_xml"))
-    __resdir = os.path.abspath(os.path.join(args.resdir, __conf['project'], __conf["tagging"]))
-    __srcdir_csv = os.path.abspath(os.path.join(args.resdir, __conf['repo'] + "_proximity", "conway"))
+    __srcdir = os.path.abspath(os.path.join(args.resdir, __conf["repo"] + "_proximity", "conway", "issues_xml"))
+    __resdir = os.path.abspath(os.path.join(args.resdir, __conf["project"], __conf["tagging"]))
+    __srcdir_csv = os.path.abspath(os.path.join(args.resdir, __conf["repo"] + "_proximity", "conway"))
 
     # get person folder
-    # __psrcdir = os.path.abspath(os.path.join(args.resdir, __conf['repo'] + "_proximity", "conway"))
+    # __psrcdir = os.path.abspath(os.path.join(args.resdir, __conf["repo"] + "_proximity", "conway"))
 
     # 1) load the list of issues
     issues = load_xml(__srcdir)
@@ -78,7 +78,7 @@ def run():
     issues = parse_xml(issues, persons, args.skip_history)
     # 3) load issue information via api
     if not args.skip_history:
-        load_issue_via_api(issues, persons, __conf['issueTrackerURL'])
+        load_issue_via_api(issues, persons, __conf["issueTrackerURL"])
     # 4) update user data with Codeface database
     # mabye not nessecary
     issues = insert_user_data(issues, __conf)
@@ -95,7 +95,8 @@ def run():
 
 
 def load_xml(source_folder):
-    """Load issues from disk.
+    """
+    Load issues from disk.
 
     :param source_folder: the folder where to find .xml-files
     :return: the loaded issue data
@@ -112,7 +113,7 @@ def load_xml(source_folder):
             log.info("Issue file '{}' does not exist! Exiting early...".format(srcfile))
             sys.exit(-1)
 
-        # with open(srcfile, 'r') as issues_file:
+        # with open(srcfile, "r") as issues_file:
         xmldoc = parse(srcfile)
         issue_data.append(xmldoc)
 
@@ -161,7 +162,8 @@ def create_user(name, username, email):
 
 
 def merge_user_with_user_from_csv(user, persons):
-    """merges list of given users with list of already known users
+    """
+    merges list of given users with list of already known users
 
     :param user: list of users to be merged
     :param persons: list of persons from JIRA (incl. e-mail addresses)
@@ -169,10 +171,10 @@ def merge_user_with_user_from_csv(user, persons):
     """
 
     new_user = dict()
-    if user['username'].lower() in persons.keys():
-        new_user['username'] = unicode(user['username'].lower()).encode('utf-8')
-        new_user['name'] = unicode(persons.get(user['username'].lower())[0]).encode('utf-8')
-        new_user['email'] = unicode(persons.get(user['username'].lower())[1]).encode('utf-8')
+    if user["username"].lower() in persons.keys():
+        new_user["username"] = unicode(user["username"].lower()).encode("utf-8")
+        new_user["name"] = unicode(persons.get(user["username"].lower())[0]).encode("utf-8")
+        new_user["email"] = unicode(persons.get(user["username"].lower())[1]).encode("utf-8")
     else:
         new_user = user
         log.warning("User not in csv-file: " + str(user))
@@ -181,7 +183,8 @@ def merge_user_with_user_from_csv(user, persons):
 
 
 def parse_xml(issue_data, persons, skip_history):
-    """Parse issues from the xml-data
+    """
+    Parse issues from the xml-data
 
     :param issue_data: list of xml-files
     :param persons: list of persons from JIRA (incl. e-mail addresses)
@@ -193,7 +196,7 @@ def parse_xml(issue_data, persons, skip_history):
     issues = list()
     log.debug("Number of files:" + str(len(issue_data)))
     for issue_file in issue_data:
-        issuelist = issue_file.getElementsByTagName('item')
+        issuelist = issue_file.getElementsByTagName("item")
         # re-process all issues
         log.debug("Number of issues:" + str(len(issuelist)))
         for issue_x in issuelist:
@@ -204,123 +207,124 @@ def parse_xml(issue_data, persons, skip_history):
 
             # parse values form xml
             # add issue values to the issue
-            key = issue_x.getElementsByTagName('key')[0]
-            issue['id'] = key.attributes['id'].value
-            issue['externalId'] = key.firstChild.data
+            key = issue_x.getElementsByTagName("key")[0]
+            issue["id"] = key.attributes["id"].value
+            issue["externalId"] = key.firstChild.data
 
-            created = issue_x.getElementsByTagName('created')[0]
+            created = issue_x.getElementsByTagName("created")[0]
             createDate = created.firstChild.data
-            issue['creationDate'] = format_time(createDate)
+            issue["creationDate"] = format_time(createDate)
 
-            resolved = issue_x.getElementsByTagName('resolved')
-            issue['resolveDate'] = ""
+            resolved = issue_x.getElementsByTagName("resolved")
+            issue["resolveDate"] = ""
             if (len(resolved) > 0) and (not resolved[0] is None):
                 resolveDate = resolved[0].firstChild.data
-                issue['resolveDate'] = format_time(resolveDate)
+                issue["resolveDate"] = format_time(resolveDate)
 
-            title = issue_x.getElementsByTagName('title')[0]
-            issue['title'] = title.firstChild.data
+            title = issue_x.getElementsByTagName("title")[0]
+            issue["title"] = title.firstChild.data
 
-            link = issue_x.getElementsByTagName('link')[0]
-            issue['url'] = link.firstChild.data
+            link = issue_x.getElementsByTagName("link")[0]
+            issue["url"] = link.firstChild.data
 
-            type = issue_x.getElementsByTagName('type')[0]
-            issue['type'] = type.firstChild.data
+            type = issue_x.getElementsByTagName("type")[0]
+            issue["type"] = type.firstChild.data
             # TODO new consistent format with GitHub issues. Not supported by the network library yet
-            issue['type_new'] = ['issue', str(type.firstChild.data.lower())]
+            issue["type_new"] = ["issue", str(type.firstChild.data.lower())]
 
-            status = issue_x.getElementsByTagName('status')[0]
-            issue['state'] = status.firstChild.data
+            status = issue_x.getElementsByTagName("status")[0]
+            issue["state"] = status.firstChild.data
             # TODO new consistent format with GitHub issues. Not supported by the network library yet
-            issue['state_new'] = status.firstChild.data.lower()
+            issue["state_new"] = status.firstChild.data.lower()
 
-            project = issue_x.getElementsByTagName('project')[0]
-            issue['projectId'] = project.attributes['id'].value
+            project = issue_x.getElementsByTagName("project")[0]
+            issue["projectId"] = project.attributes["id"].value
 
-            resolution = issue_x.getElementsByTagName('resolution')[0]
-            issue['resolution'] = resolution.firstChild.data
+            resolution = issue_x.getElementsByTagName("resolution")[0]
+            issue["resolution"] = resolution.firstChild.data
             # new consistent format with GitHub issues. Not supported by the network library yet
-            issue['resolution_new'] = [str(resolution.firstChild.data.lower())]
+            issue["resolution_new"] = [str(resolution.firstChild.data.lower())]
 
             # consistency to default GitHub labels
-            if issue['resolution'] == "Won't Fix":
-                issue['resolution_new'] = ['wontfix']
+            if issue["resolution"] == "Won't Fix":
+                issue["resolution_new"] = ["wontfix"]
 
             # consistency to default GitHub labels
-            if issue['resolution'] == "Won't Do":
-                issue['resolution_new'] = ['wontdo']
+            if issue["resolution"] == "Won't Do":
+                issue["resolution_new"] = ["wontdo"]
 
-            for component in issue_x.getElementsByTagName('component'):
+            for component in issue_x.getElementsByTagName("component"):
                 components.append(str(component.firstChild.data))
-            issue['components'] = components
+            issue["components"] = components
 
             # if links are not loaded via api, they are added as a history event with less information
             if skip_history:
-                issue['history'] = []
-                for ref in issue_x.getElementsByTagName('issuelinktype'):
+                issue["history"] = []
+                for ref in issue_x.getElementsByTagName("issuelinktype"):
                     history = dict()
-                    history['event'] = 'add_link'
-                    history['author'] = create_user('', '', '')
-                    history['date'] = ''
-                    history['event_info_1'] = ref.getElementsByTagName('issuekey')[0].firstChild.data
-                    history['event_info_2'] = "issue"
+                    history["event"] = "add_link"
+                    history["author"] = create_user("", "", "")
+                    history["date"] = ""
+                    history["event_info_1"] = ref.getElementsByTagName("issuekey")[0].firstChild.data
+                    history["event_info_2"] = "issue"
 
-                    issue['history'].append(history)
+                    issue["history"].append(history)
 
-            reporter = issue_x.getElementsByTagName('reporter')[0]
-            user = create_user(reporter.firstChild.data, reporter.attributes['username'].value, '')
-            issue['author'] = merge_user_with_user_from_csv(user, persons)
+            reporter = issue_x.getElementsByTagName("reporter")[0]
+            user = create_user(reporter.firstChild.data, reporter.attributes["username"].value, "")
+            issue["author"] = merge_user_with_user_from_csv(user, persons)
 
-            issue['title'] = issue_x.getElementsByTagName('title')[0].firstChild.data
+            issue["title"] = issue_x.getElementsByTagName("title")[0].firstChild.data
 
             # add comments / issue_changes to the issue
-            for comment_x in issue_x.getElementsByTagName('comment'):
+            for comment_x in issue_x.getElementsByTagName("comment"):
                 comment = dict()
-                comment['id'] = comment_x.attributes['id'].value
-                user = create_user('', comment_x.attributes['author'].value, '')
-                comment['author'] = merge_user_with_user_from_csv(user, persons)
-                comment['state_on_creation'] = issue['state']  # can get updated if history is retrieved
-                comment['resolution_on_creation'] = issue['resolution']  # can get updated if history is retrieved
+                comment["id"] = comment_x.attributes["id"].value
+                user = create_user("", comment_x.attributes["author"].value, "")
+                comment["author"] = merge_user_with_user_from_csv(user, persons)
+                comment["state_on_creation"] = issue["state"]  # can get updated if history is retrieved
+                comment["resolution_on_creation"] = issue["resolution"]  # can get updated if history is retrieved
 
-                created = comment_x.attributes['created'].value
-                comment['changeDate'] = format_time(created)
+                created = comment_x.attributes["created"].value
+                comment["changeDate"] = format_time(created)
 
-                comment['text'] = comment_x.firstChild.data
-                comment['issueId'] = issue['id']
+                comment["text"] = comment_x.firstChild.data
+                comment["issueId"] = issue["id"]
                 comments.append(comment)
 
-            issue['comments'] = comments
+            issue["comments"] = comments
 
             # add relations to the issue
             relations = list()
-            for rel in issue_x.getElementsByTagName('issuelinktype'):
+            for rel in issue_x.getElementsByTagName("issuelinktype"):
                 relation = dict()
-                relation['relation'] = rel.getElementsByTagName('name')[0].firstChild.data
+                relation["relation"] = rel.getElementsByTagName("name")[0].firstChild.data
 
-                if rel.hasAttribute('inwardlinks'):
-                    left = rel.getElementsByTagName('inwardlinks')
+                if rel.hasAttribute("inwardlinks"):
+                    left = rel.getElementsByTagName("inwardlinks")
                     issuekeys = left.getElementsByTagName("issuekey")
                     for key in issuekeys:
-                        relation['type'] = "inward"
-                        relation['id'] = key.firstChild.data
+                        relation["type"] = "inward"
+                        relation["id"] = key.firstChild.data
                         relations.append(relation)
 
-                if rel.hasAttribute('outwardlinks'):
-                    right = rel.getElementsByTagName('outwardlinks')
-                    issuekeys = right.getElementsByTagName('issuekey')
+                if rel.hasAttribute("outwardlinks"):
+                    right = rel.getElementsByTagName("outwardlinks")
+                    issuekeys = right.getElementsByTagName("issuekey")
                     for key in issuekeys:
-                        relation['type'] = "outward"
-                        relation['id'] = key.firstChild.data
+                        relation["type"] = "outward"
+                        relation["id"] = key.firstChild.data
                         relations.append(relation)
 
-            issue['relations'] = relations
+            issue["relations"] = relations
             issues.append(issue)
     log.debug("number of issues after parse_xml: '{}'".format(len(issues)))
     return issues
 
 
 def load_issue_via_api(issues, persons, url):
-    """For each issue in the list the history is added via the api
+    """
+    For each issue in the list the history is added via the api
 
         :param issues: list of issues
         :param persons: list of persons from JIRA (incl. e-mail addresses)
@@ -332,118 +336,119 @@ def load_issue_via_api(issues, persons, url):
 
     for issue in issues:
 
-        api_issue = jira_project.issue(issue['externalId'], expand='changelog')
+        api_issue = jira_project.issue(issue["externalId"], expand="changelog")
         changelog = api_issue.changelog
         histories = list()
 
         # adds the issue creation time with the default state to an list
         # list is needed to find out the state the issue had when a comment was written
-        state_changes = [[issue['creationDate'], "open"]]
+        state_changes = [[issue["creationDate"], "open"]]
 
         # adds the issue creation time with the default resolution to an list
         # list is needed to find out the resolution the issue had when a comment was written
-        resolution_changes = [[issue['creationDate'], "unresolved"]]
+        resolution_changes = [[issue["creationDate"], "unresolved"]]
 
         # history changes get visited in time order from oldest to newest
         for change in changelog.histories:
 
             # default values for state and resolution
-            old_state, new_state, old_resolution, new_resolution = 'open', 'open', 'unresolved', 'unresolved'
+            old_state, new_state, old_resolution, new_resolution = "open", "open", "unresolved", "unresolved"
 
             # all changes in the issue changelog are checked if they contain an useful information
             for item in change.items:
 
                 # state_updated event gets created and added to the issue history
-                if item.field == 'status':
+                if item.field == "status":
                     if item.fromString is not None:
                         old_state = item.fromString.lower()
                     if item.toString is not None:
                         new_state = item.toString.lower()
                     history = dict()
-                    history['event'] = 'state_updated'
-                    history['event_info_1'] = new_state
-                    history['event_info_2'] = old_state
+                    history["event"] = "state_updated"
+                    history["event_info_1"] = new_state
+                    history["event_info_2"] = old_state
                     user = create_user(change.author.name, change.author.name, "")
-                    history['author'] = merge_user_with_user_from_csv(user, persons)
-                    history['date'] = format_time(change.created)
+                    history["author"] = merge_user_with_user_from_csv(user, persons)
+                    history["date"] = format_time(change.created)
                     histories.append(history)
-                    state_changes.append([history['date'], new_state])
+                    state_changes.append([history["date"], new_state])
 
                 # resolution_updated event gets created and added to the issue history
-                elif item.field == 'resolution':
+                elif item.field == "resolution":
                     if item.fromString is not None:
                         old_resolution = item.fromString.lower()
                     if item.toString is not None:
                         new_resolution = item.toString.lower()
                     history = dict()
-                    history['event'] = 'resolution_updated'
-                    history['event_info_1'] = new_resolution
-                    history['event_info_2'] = old_resolution
+                    history["event"] = "resolution_updated"
+                    history["event_info_1"] = new_resolution
+                    history["event_info_2"] = old_resolution
                     user = create_user(change.author.name, change.author.name, "")
-                    history['author'] = merge_user_with_user_from_csv(user, persons)
-                    history['date'] = format_time(change.created)
+                    history["author"] = merge_user_with_user_from_csv(user, persons)
+                    history["date"] = format_time(change.created)
                     histories.append(history)
-                    resolution_changes.append([history['date'], new_resolution])
+                    resolution_changes.append([history["date"], new_resolution])
 
                 # assigned event gets created and added to the issue history
-                elif item.field == 'assignee':
+                elif item.field == "assignee":
                     history = dict()
-                    history['event'] = 'assigned'
+                    history["event"] = "assigned"
                     user = create_user(change.author.name, change.author.name, "")
-                    history['author'] = merge_user_with_user_from_csv(user, persons)
+                    history["author"] = merge_user_with_user_from_csv(user, persons)
                     assignee = create_user(item.toString, item.toString, "")
                     assigned_user = merge_user_with_user_from_csv(assignee, persons)
-                    history['event_info_1'] = assigned_user['name']
-                    history['event_info_2'] = assigned_user['email']
-                    history['date'] = format_time(change.created)
+                    history["event_info_1"] = assigned_user["name"]
+                    history["event_info_2"] = assigned_user["email"]
+                    history["date"] = format_time(change.created)
                     histories.append(history)
 
-                elif item.field == 'Link':
+                elif item.field == "Link":
                     # add_link event gets created and added to the issue history
                     if item.toString is not None:
                         history = dict()
-                        history['event'] = 'add_link'
+                        history["event"] = "add_link"
                         user = create_user(change.author.name, change.author.name, "")
-                        history['author'] = merge_user_with_user_from_csv(user, persons)
+                        history["author"] = merge_user_with_user_from_csv(user, persons)
                         # api returns a text. The issueId is at the end of the text and gets extracted
-                        history['event_info_1'] = item.toString.split()[-1]
-                        history['event_info_2'] = "issue"
-                        history['date'] = format_time(change.created)
+                        history["event_info_1"] = item.toString.split()[-1]
+                        history["event_info_2"] = "issue"
+                        history["date"] = format_time(change.created)
                         histories.append(history)
 
                     # remove_link event gets created and added to the issue history
                     if item.fromString is not None:
                         history = dict()
-                        history['event'] = 'remove_link'
+                        history["event"] = "remove_link"
                         user = create_user(change.author.name, change.author.name, "")
-                        history['author'] = merge_user_with_user_from_csv(user, persons)
+                        history["author"] = merge_user_with_user_from_csv(user, persons)
                         # api returns a text. Th issue id is at the end of the text and gets extracted
-                        history['event_info_1'] = item.fromString.split()[-1]
-                        history['event_info_2'] = "issue"
-                        history['date'] = format_time(change.created)
+                        history["event_info_1"] = item.fromString.split()[-1]
+                        history["event_info_2"] = "issue"
+                        history["date"] = format_time(change.created)
                         histories.append(history)
 
         # state and resolution change lists get sorted by time
         state_changes.sort(key=lambda x: x[0])
         resolution_changes.sort(key=lambda x: x[0])
 
-        for comment in issue['comments']:
+        for comment in issue["comments"]:
 
             # the state the issue had when the comment was written is searched out
             for state in state_changes:
-                if comment['changeDate'] > state[0]:
-                    comment['state_on_creation'] = state[1]
+                if comment["changeDate"] > state[0]:
+                    comment["state_on_creation"] = state[1]
 
             # the resolution the issue had when the comment was written is searched out
             for resolution in resolution_changes:
-                if comment['changeDate'] > resolution[0]:
-                    comment['resolution_on_creation'] = [str(resolution[1])]
+                if comment["changeDate"] > resolution[0]:
+                    comment["resolution_on_creation"] = [str(resolution[1])]
 
-        issue['history'] = histories
+        issue["history"] = histories
 
 
 def insert_user_data(issues, conf):
-    """Insert user data into database ad update issue data.
+    """
+    Insert user data into database ad update issue data.
 
     :param issues: the issues to retrieve user data from
     :param conf: the project configuration
@@ -487,9 +492,9 @@ def insert_user_data(issues, conf):
 
         # update user data with person information from DB
         person = idservice.getPersonFromDB(idx)
-        user["email"] = person["email1"]  # column 'email1'
-        user["name"] = person["name"]  # column 'name'
-        user["id"] = person["id"]  # column 'id'
+        user["email"] = person["email1"]  # column "email1"
+        user["name"] = person["name"]  # column "name"
+        user["id"] = person["id"]  # column "id"
 
         # add user information to buffer
         # user_string = get_user_string(user["name"], user["email"]) # update for
@@ -514,10 +519,11 @@ def insert_user_data(issues, conf):
 
 
 def print_to_disk(issues, results_folder):
-    """Print issues to file 'issues-jira.list' in result folder
+    """
+    Print issues to file "issues-jira.list" in result folder
 
     :param issues: the issues to dump
-    :param results_folder: the folder where to place 'issues-jira.list' output file
+    :param results_folder: the folder where to place "issues-jira.list" output file
     """
 
     # construct path to output file
@@ -527,20 +533,20 @@ def print_to_disk(issues, results_folder):
     # construct lines of output
     lines = []
     for issue in issues:
-        log.info("Current issue '{}'".format(issue['externalId']))
-        lines.append((issue["author"]['name'],
-                      issue["author"]['email'],
-                      issue['externalId'],
-                      issue['creationDate'],
-                      issue['externalId'],
-                      issue['type']))
+        log.info("Current issue '{}'".format(issue["externalId"]))
+        lines.append((issue["author"]["name"],
+                      issue["author"]["email"],
+                      issue["externalId"],
+                      issue["creationDate"],
+                      issue["externalId"],
+                      issue["type"]))
         for comment in issue["comments"]:
             lines.append((
-                comment['author']['name'],
-                comment['author']['email'],
+                comment["author"]["name"],
+                comment["author"]["email"],
                 comment["id"],
-                comment['changeDate'],
-                issue['externalId'],
+                comment["changeDate"],
+                issue["externalId"],
                 "comment"
             ))
     # write to output file
@@ -549,12 +555,12 @@ def print_to_disk(issues, results_folder):
 
 def print_to_disk_bugs(issues, results_folder):
     """
-    Sorts of bug issues and prints them to file 'bugs-jira.list' in result folder
-    This method prints in a new format which is consistent to the format of 'print_to_disk_new' in 'issue_processing.py'.
+    Sorts of bug issues and prints them to file "bugs-jira.list" in result folder
+    This method prints in a new format which is consistent to the format of "print_to_disk_new" in "issue_processing.py".
     TODO When the network library is updated this format shall be used in all print to disk methods.
 
     :param issues: the issues to sort of bugs
-    :param results_folder: the folder where to place 'bugs-jira.list' output file
+    :param results_folder: the folder where to place "bugs-jira.list" output file
     """
 
     # construct path to output file
@@ -564,78 +570,78 @@ def print_to_disk_bugs(issues, results_folder):
     # construct lines of output
     lines = []
     for issue in issues:
-        log.info("Current issue '{}'".format(issue['externalId']))
+        log.info("Current issue '{}'".format(issue["externalId"]))
 
         # only writes issues with type bug and their comments in the output file
-        if 'bug' in issue['type_new']:
+        if "bug" in issue["type_new"]:
             lines.append((
-                issue['externalId'],
-                issue['title'],
-                issue['type_new'],
-                issue['state_new'],
-                issue['resolution_new'],
-                issue['creationDate'],
-                issue['resolveDate'],
-                issue['components'],
+                issue["externalId"],
+                issue["title"],
+                issue["type_new"],
+                issue["state_new"],
+                issue["resolution_new"],
+                issue["creationDate"],
+                issue["resolveDate"],
+                issue["components"],
                 "created",  ## event.name
-                issue['author']['name'],
-                issue['author']['email'],
-                issue['creationDate'],
+                issue["author"]["name"],
+                issue["author"]["email"],
+                issue["creationDate"],
                 "open",  ## default state when created
-                ['unresolved']  ## default resolution when created
+                ["unresolved"]  ## default resolution when created
             ))
 
             lines.append((
-                issue['externalId'],
-                issue['title'],
-                issue['type_new'],
-                issue['state_new'],
-                issue['resolution_new'],
-                issue['creationDate'],
-                issue['resolveDate'],
-                issue['components'],
+                issue["externalId"],
+                issue["title"],
+                issue["type_new"],
+                issue["state_new"],
+                issue["resolution_new"],
+                issue["creationDate"],
+                issue["resolveDate"],
+                issue["components"],
                 "commented",
-                issue['author']['name'],
-                issue['author']['email'],
-                issue['creationDate'],
+                issue["author"]["name"],
+                issue["author"]["email"],
+                issue["creationDate"],
                 "open",  ##  default state when created
                 "unresolved"  ## default resolution when created
             ))
 
-            for comment in issue['comments']:
+            for comment in issue["comments"]:
                 lines.append((
-                    issue['externalId'],
-                    issue['title'],
-                    issue['type_new'],
-                    issue['state_new'],
-                    issue['resolution_new'],
-                    issue['creationDate'],
-                    issue['resolveDate'],
-                    issue['components'],
+                    issue["externalId"],
+                    issue["title"],
+                    issue["type_new"],
+                    issue["state_new"],
+                    issue["resolution_new"],
+                    issue["creationDate"],
+                    issue["resolveDate"],
+                    issue["components"],
                     "commented",
-                    comment['author']['name'],
-                    comment['author']['email'],
-                    comment['changeDate'],
-                    comment['state_on_creation'],
-                    comment['resolution_on_creation']
+                    comment["author"]["name"],
+                    comment["author"]["email"],
+                    comment["changeDate"],
+                    comment["state_on_creation"],
+                    comment["resolution_on_creation"]
                 ))
 
-            for history in issue['history']:
+            for history in issue["history"]:
                 lines.append((
-                    issue['externalId'],
-                    issue['title'],
-                    issue['type_new'],
-                    issue['state_new'],
-                    issue['resolution_new'],
-                    issue['creationDate'],
-                    issue['resolveDate'],
-                    issue['components'],
-                    history['event'],
-                    history['author']['name'],
-                    history['author']['email'],
-                    history['date'],
-                    history['event_info_1'],
-                    history['event_info_2']
+                    issue["externalId"],
+                    issue["title"],
+                    issue["type_new"],
+                    issue["state_new"],
+                    issue["resolution_new"],
+                    issue["creationDate"],
+                    issue["resolveDate"],
+                    issue["components"],
+                    history["event"],
+                    history["author"]["name"],
+                    history["author"]["email"],
+                    history["date"],
+                    history["event_info_1"],
+                    history["event_info_2"]
                 ))
 
     # write to output file
@@ -643,10 +649,11 @@ def print_to_disk_bugs(issues, results_folder):
 
 
 def print_to_disk_extr(issues, results_folder):
-    """Print issues to file 'issues.list' in result folder
+    """
+    Print issues to file "issues.list" in result folder
 
     :param issues: the issues to dump
-    :param results_folder: the folder where to place 'issues.list' output file
+    :param results_folder: the folder where to place "issues.list" output file
     """
 
     # construct path to output file
@@ -656,44 +663,44 @@ def print_to_disk_extr(issues, results_folder):
     # construct lines of output
     lines = []
     for issue in issues:
-        log.info("Current issue '{}'".format(issue['externalId']))
+        log.info("Current issue '{}'".format(issue["externalId"]))
 
         lines.append((
-            issue['externalId'],
-            issue['state'],
-            issue['creationDate'],
-            issue['resolveDate'],
+            issue["externalId"],
+            issue["state"],
+            issue["creationDate"],
+            issue["resolveDate"],
             False,  ## Value of is.pull.request
-            issue['author']['name'],
-            issue['author']['email'],
-            issue['creationDate'],
+            issue["author"]["name"],
+            issue["author"]["email"],
+            issue["creationDate"],
             "",  ## ref.name
             "open"  ## event.name
         ))
 
         lines.append((
-            issue['externalId'],
-            issue['state'],
-            issue['creationDate'],
-            issue['resolveDate'],
+            issue["externalId"],
+            issue["state"],
+            issue["creationDate"],
+            issue["resolveDate"],
             False,  ## Value of is.pull.request
-            issue['author']['name'],
-            issue['author']['email'],
-            issue['creationDate'],
+            issue["author"]["name"],
+            issue["author"]["email"],
+            issue["creationDate"],
             "",  ## ref.name
             "commented"  ## event.name
         ))
 
         for comment in issue["comments"]:
             lines.append((
-                issue['externalId'],
-                issue['state'],
-                issue['creationDate'],
-                issue['resolveDate'],
+                issue["externalId"],
+                issue["state"],
+                issue["creationDate"],
+                issue["resolveDate"],
                 False,  ## Value of is.pull.request
-                comment['author']['name'],
-                comment['author']['email'],
-                comment['changeDate'],
+                comment["author"]["name"],
+                comment["author"]["email"],
+                comment["changeDate"],
                 "",  ## ref.name
                 "commented"  ## event.name
             ))
@@ -702,8 +709,9 @@ def print_to_disk_extr(issues, results_folder):
 
 
 def print_to_disk_gephi(issues, results_folder):
-    """Print issues to file 'issues-jira-gephi-nodes.csv' and
-    'issues-jira-gephi-edges.csv' in result folder. The files can be
+    """
+    Print issues to file "issues-jira-gephi-nodes.csv" and
+    "issues-jira-gephi-edges.csv" in result folder. The files can be
      used to build dynamic networks in Gephi.
 
     :param issues: the issues to dump
@@ -722,17 +730,17 @@ def print_to_disk_gephi(issues, results_folder):
     node_lines.append(("Id", "Type"))
     edge_lines.append(("Source", "Target", "Timestamp", "Edgetype"))
     for issue in issues:
-        node_lines.append((issue['externalId'], "Issue"))
-        node_lines.append((issue["author"]['name'], "Person"))
+        node_lines.append((issue["externalId"], "Issue"))
+        node_lines.append((issue["author"]["name"], "Person"))
 
-        edge_lines.append((issue["author"]['name'], issue['externalId'], issue['creationDate'], "Person-Issue"))
+        edge_lines.append((issue["author"]["name"], issue["externalId"], issue["creationDate"], "Person-Issue"))
         for comment in issue["comments"]:
-            node_lines.append((comment['id'], "Comment"))
-            node_lines.append((comment['author']['name'], "Person"))
+            node_lines.append((comment["id"], "Comment"))
+            node_lines.append((comment["author"]["name"], "Person"))
 
-            edge_lines.append((issue['externalId'], comment['id'], comment['changeDate'],
+            edge_lines.append((issue["externalId"], comment["id"], comment["changeDate"],
                                "Issue-Comment"))
-            edge_lines.append((comment['author']['name'], comment['id'], ['changeDate'],
+            edge_lines.append((comment["author"]["name"], comment["id"], ["changeDate"],
                                "Person-Comment"))
     # write to output file
     csv_writer.write_to_csv(output_file_edges, edge_lines)
@@ -740,7 +748,8 @@ def print_to_disk_gephi(issues, results_folder):
 
 
 def load_csv(source_folder):
-    """Load persons from disk.
+    """
+    Load persons from disk.
 
     :param source_folder: the folder where to find .csv-file
     :return: the loaded person data
@@ -776,11 +785,11 @@ def load_csv(source_folder):
         sys.exit(-1)
 
     log.devinfo("Loading person csv from file '{}'...".format(srcfile))
-    with open(srcfile, 'r') as f:
-        person_data = csv.DictReader(f, delimiter=',', skipinitialspace=True)
+    with open(srcfile, "r") as f:
+        person_data = csv.DictReader(f, delimiter=",", skipinitialspace=True)
         persons = {}
         for row in person_data:
-            if not row['AuthorID'] in persons.keys():
-                persons[row['AuthorID']] = (row['AuthorName'], row['userEmail'])
+            if not row["AuthorID"] in persons.keys():
+                persons[row["AuthorID"]] = (row["AuthorName"], row["userEmail"])
 
     return persons

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -334,8 +334,10 @@ def load_issue_via_api(issues, persons, url):
 
                 # state_updated event gets created and added to the issue history
                 if item.field == 'status':
-                    old_state = item.fromString.lower()
-                    new_state = item.toString.lower()
+                    if item.fromString is not None:
+                        old_state = item.fromString.lower()
+                    if item.toString is not None:
+                        new_state = item.toString.lower()
                     history = dict()
                     history['event'] = 'state_updated'
                     history['event_info_1'] = new_state
@@ -544,7 +546,7 @@ def print_to_disk(issues, results_folder):
 
 def print_to_disk_bugs(issues, results_folder):
     """Sorts of bug issues and prints them to file 'bugs-jira.list' in result folder
-    This method prints in a new format which is consistent to the GitHub format.
+    This method prints in a new format which is consistent to the new GitHub format.
     When the network library is updated this format shall be used in all print to disk methods.
 
     :param issues: the issues to sort of bugs
@@ -691,7 +693,6 @@ def print_to_disk_extr(issues, results_folder):
                 "",  ## ref.name
                 "commented"  ## event.name
             ))
-
     # write to output file
     csv_writer.write_to_csv(output_file, lines)
 

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -145,6 +145,13 @@ def create_user(name, username, email):
     :return: the created user object
     """
 
+    if name is None:
+        name = ""
+    if username is None:
+        username = ""
+    if email is None:
+        email = ""
+
     user = dict()
     user["name"] = name
     user["username"] = username

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -178,6 +178,9 @@ def parse_xml(issue_data, persons, skip_history):
                 d = datetime.strptime(resolveDate, '%a, %d %b %Y %H:%M:%S +0000')
                 issue['resolveDate'] = d.strftime('%Y-%m-%d %H:%M:%S')
 
+            title = issue_x.getElementsByTagName('title')[0]
+            issue['title'] = title.firstChild.data
+
             link = issue_x.getElementsByTagName('link')[0]
             issue['url'] = link.firstChild.data
 
@@ -561,6 +564,7 @@ def print_to_disk_bugs(issues, results_folder):
         if 'bug' in issue['type_new']:
             lines.append((
                 issue['externalId'],
+                issue['title'],
                 issue['type_new'],
                 issue['state_new'],
                 issue['resolution_new'],
@@ -577,6 +581,7 @@ def print_to_disk_bugs(issues, results_folder):
 
             lines.append((
                 issue['externalId'],
+                issue['title'],
                 issue['type_new'],
                 issue['state_new'],
                 issue['resolution_new'],
@@ -594,6 +599,7 @@ def print_to_disk_bugs(issues, results_folder):
             for comment in issue["comments"]:
                 lines.append((
                     issue['externalId'],
+                    issue['title'],
                     issue['type_new'],
                     issue['state_new'],
                     issue['resolution_new'],
@@ -611,6 +617,7 @@ def print_to_disk_bugs(issues, results_folder):
             for history in issue['history']:
                 lines.append((
                     issue['externalId'],
+                    issue['title'],
                     issue['type_new'],
                     issue['state_new'],
                     issue['resolution_new'],


### PR DESCRIPTION
'issue_processing.py' and 'jira_issue_processing.py' get adjusted, so
they both can print a '.list' file with a consistent format. The new
format is:
"issue number";"issue name";"[issue types]";"issue state";"issue creation
date";"issue resolve date";"[issue components]";"event type";"event user
name";"event user e-mail";"event time";"event info 1";"event info 2"

Attached diagram gives a overview about how the extraction to the new format works:
[codeface-data-extraction-diagramm.pdf](https://github.com/se-passau/codeface-extraction/files/2265443/codeface-data-extraction-diagramm.pdf)

For now only the methods 'print_to_disk_new' ('issue_processing.py') and
'print_to_disk_bugs' ('jira_issue_processing.py') use this new format,
because the network library only supports the old format. When the
network library is updated all output methods shall use this format.

This fixes #91.

Signed-off-by: Anselm Fehnker <fehnker@fim.uni-passau.de>


