### PR TITLE
Change jira-issue-processing workflow

### DIFF
--- a/csv_writer/csv_writer.py
+++ b/csv_writer/csv_writer.py
@@ -13,6 +13,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright 2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
+# Copyright 2018 by Anselm Fehnker <fehnker@fim.uni-passau.de>
 # All Rights Reserved.
 """
 This file provides the needed functions for standardized CSV writing

--- a/csv_writer/csv_writer.py
+++ b/csv_writer/csv_writer.py
@@ -34,13 +34,28 @@ def __encode(line):
     return lineres
 
 
-def write_to_csv(file_path, lines):
-    """Write the given lines to the file with the given file path."""
+def write_to_csv(file_path, lines, append=False):
+    """
+    Write the given lines to the file with the given file path.
+    :param file_path: The path where the file shall be written
+    :param lines: The lines that shall be written in the file
+    :param append: Flag if lines shall be appended to file or overwrite file
+    """
 
-    # write lines to file for current kind of artifact
-    with open(file_path, 'wb') as csv_file:
-        wr = csv.writer(csv_file, delimiter=';', lineterminator='\n', quoting=csv.QUOTE_NONNUMERIC)
-        # encode in proper UTF-8 before writing to file
-        for line in lines:
-            line_encoded = __encode(line)
-            wr.writerow(line_encoded)
+    if append:
+        # append lines to file for current kind of artifact
+        with open(file_path, 'a') as csv_file:
+            wr = csv.writer(csv_file, delimiter=';', lineterminator='\n', quoting=csv.QUOTE_NONNUMERIC)
+            # encode in proper UTF-8 before writing to file
+            for line in lines:
+                line_encoded = __encode(line)
+                wr.writerow(line_encoded)
+
+    else:
+        # write lines to file for current kind of artifact
+        with open(file_path, 'wb') as csv_file:
+            wr = csv.writer(csv_file, delimiter=';', lineterminator='\n', quoting=csv.QUOTE_NONNUMERIC)
+            # encode in proper UTF-8 before writing to file
+            for line in lines:
+                line_encoded = __encode(line)
+                wr.writerow(line_encoded)

--- a/csv_writer/csv_writer.py
+++ b/csv_writer/csv_writer.py
@@ -38,25 +38,17 @@ def __encode(line):
 def write_to_csv(file_path, lines, append=False):
     """
     Write the given lines to the file with the given file path.
+
     :param file_path: The path where the file shall be written
     :param lines: The lines that shall be written in the file
     :param append: Flag if lines shall be appended to file or overwrite file
     """
 
-    if append:
-        # append lines to file for current kind of artifact
-        with open(file_path, 'a') as csv_file:
-            wr = csv.writer(csv_file, delimiter=';', lineterminator='\n', quoting=csv.QUOTE_NONNUMERIC)
-            # encode in proper UTF-8 before writing to file
-            for line in lines:
-                line_encoded = __encode(line)
-                wr.writerow(line_encoded)
+    open_mode = "a+b" if append else "wb"
 
-    else:
-        # write lines to file for current kind of artifact
-        with open(file_path, 'wb') as csv_file:
-            wr = csv.writer(csv_file, delimiter=';', lineterminator='\n', quoting=csv.QUOTE_NONNUMERIC)
-            # encode in proper UTF-8 before writing to file
-            for line in lines:
-                line_encoded = __encode(line)
-                wr.writerow(line_encoded)
+    with open(file_path, open_mode) as csv_file:
+        wr = csv.writer(csv_file, delimiter=';', lineterminator='\n', quoting=csv.QUOTE_NONNUMERIC)
+        # encode in proper UTF-8 before writing to file
+        for line in lines:
+            line_encoded = __encode(line)
+            wr.writerow(line_encoded)

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -79,10 +79,17 @@ def run():
     # creates empty result files
     clear_result_files(__resdir)
 
+    # list for malformed or missing xml-files
+    incorrect_files = []
+
     # processes every xml-file
-    for file in file_list:
+    for current_file in file_list:
         # 1) load the list of issues
-        issues = load_xml(__srcdir, file)
+        issues = load_xml(__srcdir, current_file)
+        # if an error occurred while loading the xml-file
+        if issues is None:
+            incorrect_files.append(current_file)
+            continue
         # 2) re-format the issues
         issues = parse_xml(issues, persons, args.skip_history)
         # 3) load issue information via api
@@ -102,52 +109,49 @@ def run():
 
     log.info("Jira issue processing complete!")
 
+    if incorrect_files:
+        log.info("Following files where malformed or not existing:: " + str(incorrect_files))
+
 
 def clear_result_files(results_folder):
     """
     Creates an empty csv file for every result file.
+
     :param results_folder: the folder where to save the result files
     """
 
     log.info("Clear result files ...")
 
-    # construct path to output files
-    output_file = os.path.join(results_folder, "issues-jira.list")
-    output_file_bugs = os.path.join(results_folder, "bugs-jira.list")
-    output_file_extr = os.path.join(results_folder, "issue-jiras.list")
-    output_file_gephi_edges = os.path.join(results_folder, "issues-jira-gephi-edges.csv")
-    output_file_gephi_nodes = os.path.join(results_folder, "issues-jira-gephi-nodes.csv")
+    # construct list of path to output files
+    output_files = [os.path.join(results_folder, "issues-jira.list"), os.path.join(results_folder, "bugs-jira.list"),
+                    os.path.join(results_folder, "issue-jira.list"),
+                    os.path.join(results_folder, "issues-jira-gephi-edges.csv"),
+                    os.path.join(results_folder, "issues-jira-gephi-nodes.csv")]
 
     # creates empty csv files
-    csv_writer.write_to_csv(output_file, [])
-    csv_writer.write_to_csv(output_file_bugs, [])
-    csv_writer.write_to_csv(output_file_extr, [])
-    csv_writer.write_to_csv(output_file_gephi_edges, [])
-    csv_writer.write_to_csv(output_file_gephi_nodes, [])
+    for output_file in output_files:
+        open(output_file, "w+").close()
 
 
-def load_xml(source_folder, file):
+def load_xml(source_folder, xml_file):
     """
     Load issues from disk.
 
-    :param source_folder: the folder where to find .xml-files
+    :param source_folder: the folder where to .xml-file is in
+    :param xml_file: the given xml-file
     :return: the loaded issue data
     """
 
-    issue_data = list()
-    srcfile = os.path.join(source_folder, file)
+    srcfile = os.path.join(source_folder, xml_file)
     log.devinfo("Loading issues from file '{}'...".format(srcfile))
 
-    # check if file exists and exit early if not
-    if not os.path.exists(srcfile):
-        log.info("Issue file '{}' does not exist! Exiting early...".format(srcfile))
-        sys.exit(-1)
-
-    # with open(srcfile, "r") as issues_file:
-    xmldoc = parse(srcfile)
-    issue_data.append(xmldoc)
-
-    return issue_data
+    try:
+        # parse the xml-file
+        issue_data = parse(srcfile)
+        return issue_data
+    except Exception as e:
+        log.info("Issue file " + format(srcfile) + " couldn't be opened because of a " + e.__class__.__name__)
+        return None
 
 
 def format_time(time):
@@ -224,130 +228,128 @@ def parse_xml(issue_data, persons, skip_history):
 
     log.info("Parse jira issues...")
     issues = list()
-    log.debug("Number of files:" + str(len(issue_data)))
-    for issue_file in issue_data:
-        issuelist = issue_file.getElementsByTagName("item")
-        # re-process all issues
-        log.debug("Number of issues:" + str(len(issuelist)))
-        for issue_x in issuelist:
-            # temporary container for references
-            comments = list()
-            issue = dict()
-            components = []
+    issuelist = issue_data.getElementsByTagName("item")
+    # re-process all issues
+    log.debug("Number of issues:" + str(len(issuelist)))
+    for issue_x in issuelist:
+        # temporary container for references
+        comments = list()
+        issue = dict()
+        components = []
 
-            # parse values form xml
-            # add issue values to the issue
-            key = issue_x.getElementsByTagName("key")[0]
-            issue["id"] = key.attributes["id"].value
-            issue["externalId"] = key.firstChild.data
+        # parse values form xml
+        # add issue values to the issue
+        key = issue_x.getElementsByTagName("key")[0]
+        issue["id"] = key.attributes["id"].value
+        issue["externalId"] = key.firstChild.data
 
-            created = issue_x.getElementsByTagName("created")[0]
-            createDate = created.firstChild.data
-            issue["creationDate"] = format_time(createDate)
+        created = issue_x.getElementsByTagName("created")[0]
+        createDate = created.firstChild.data
+        issue["creationDate"] = format_time(createDate)
 
-            resolved = issue_x.getElementsByTagName("resolved")
-            issue["resolveDate"] = ""
-            if (len(resolved) > 0) and (not resolved[0] is None):
-                resolveDate = resolved[0].firstChild.data
-                issue["resolveDate"] = format_time(resolveDate)
+        resolved = issue_x.getElementsByTagName("resolved")
+        issue["resolveDate"] = ""
+        if (len(resolved) > 0) and (not resolved[0] is None):
+            resolveDate = resolved[0].firstChild.data
+            issue["resolveDate"] = format_time(resolveDate)
 
-            title = issue_x.getElementsByTagName("title")[0]
-            issue["title"] = title.firstChild.data
+        title = issue_x.getElementsByTagName("title")[0]
+        issue["title"] = title.firstChild.data
 
-            link = issue_x.getElementsByTagName("link")[0]
-            issue["url"] = link.firstChild.data
+        link = issue_x.getElementsByTagName("link")[0]
+        issue["url"] = link.firstChild.data
 
-            type = issue_x.getElementsByTagName("type")[0]
-            issue["type"] = type.firstChild.data
-            # TODO new consistent format with GitHub issues. Not supported by the network library yet
-            issue["type_new"] = ["issue", str(type.firstChild.data.lower())]
+        type = issue_x.getElementsByTagName("type")[0]
+        issue["type"] = type.firstChild.data
+        # TODO new consistent format with GitHub issues. Not supported by the network library yet
+        issue["type_new"] = ["issue", str(type.firstChild.data.lower())]
 
-            status = issue_x.getElementsByTagName("status")[0]
-            issue["state"] = status.firstChild.data
-            # TODO new consistent format with GitHub issues. Not supported by the network library yet
-            issue["state_new"] = status.firstChild.data.lower()
+        status = issue_x.getElementsByTagName("status")[0]
+        issue["state"] = status.firstChild.data
+        # TODO new consistent format with GitHub issues. Not supported by the network library yet
+        issue["state_new"] = status.firstChild.data.lower()
 
-            project = issue_x.getElementsByTagName("project")[0]
-            issue["projectId"] = project.attributes["id"].value
+        project = issue_x.getElementsByTagName("project")[0]
+        issue["projectId"] = project.attributes["id"].value
 
-            resolution = issue_x.getElementsByTagName("resolution")[0]
-            issue["resolution"] = resolution.firstChild.data
-            # new consistent format with GitHub issues. Not supported by the network library yet
-            issue["resolution_new"] = [str(resolution.firstChild.data.lower())]
+        resolution = issue_x.getElementsByTagName("resolution")[0]
+        issue["resolution"] = resolution.firstChild.data
+        # new consistent format with GitHub issues. Not supported by the network library yet
+        issue["resolution_new"] = [str(resolution.firstChild.data.lower())]
 
-            # consistency to default GitHub labels
-            if issue["resolution"] == "Won't Fix":
-                issue["resolution_new"] = ["wontfix"]
+        # consistency to default GitHub labels
+        if issue["resolution"] == "Won't Fix":
+            issue["resolution_new"] = ["wontfix"]
 
-            # consistency to default GitHub labels
-            if issue["resolution"] == "Won't Do":
-                issue["resolution_new"] = ["wontdo"]
+        # consistency to default GitHub labels
+        if issue["resolution"] == "Won't Do":
+            issue["resolution_new"] = ["wontdo"]
 
-            for component in issue_x.getElementsByTagName("component"):
-                components.append(str(component.firstChild.data))
-            issue["components"] = components
+        for component in issue_x.getElementsByTagName("component"):
+            components.append(str(component.firstChild.data))
+        issue["components"] = components
 
-            # if links are not loaded via api, they are added as a history event with less information
-            if skip_history:
-                issue["history"] = []
-                for ref in issue_x.getElementsByTagName("issuelinktype"):
-                    history = dict()
-                    history["event"] = "add_link"
-                    history["author"] = create_user("", "", "")
-                    history["date"] = ""
-                    history["event_info_1"] = ref.getElementsByTagName("issuekey")[0].firstChild.data
-                    history["event_info_2"] = "issue"
+        # if links are not loaded via api, they are added as a history event with less information
+        if skip_history:
+            issue["history"] = []
+            for ref in issue_x.getElementsByTagName("issuelinktype"):
+                history = dict()
+                history["event"] = "add_link"
+                history["author"] = create_user("", "", "")
+                history["date"] = ""
+                history["event_info_1"] = ref.getElementsByTagName("issuekey")[0].firstChild.data
+                history["event_info_2"] = "issue"
 
-                    issue["history"].append(history)
+                issue["history"].append(history)
 
-            reporter = issue_x.getElementsByTagName("reporter")[0]
-            user = create_user(reporter.firstChild.data, reporter.attributes["username"].value, "")
-            issue["author"] = merge_user_with_user_from_csv(user, persons)
+        reporter = issue_x.getElementsByTagName("reporter")[0]
+        user = create_user(reporter.firstChild.data, reporter.attributes["username"].value, "")
+        issue["author"] = merge_user_with_user_from_csv(user, persons)
 
-            issue["title"] = issue_x.getElementsByTagName("title")[0].firstChild.data
+        issue["title"] = issue_x.getElementsByTagName("title")[0].firstChild.data
 
-            # add comments / issue_changes to the issue
-            for comment_x in issue_x.getElementsByTagName("comment"):
-                comment = dict()
-                comment["id"] = comment_x.attributes["id"].value
-                user = create_user("", comment_x.attributes["author"].value, "")
-                comment["author"] = merge_user_with_user_from_csv(user, persons)
-                comment["state_on_creation"] = issue["state"]  # can get updated if history is retrieved
-                comment["resolution_on_creation"] = issue["resolution"]  # can get updated if history is retrieved
+        # add comments / issue_changes to the issue
+        for comment_x in issue_x.getElementsByTagName("comment"):
+            comment = dict()
+            comment["id"] = comment_x.attributes["id"].value
+            user = create_user("", comment_x.attributes["author"].value, "")
+            comment["author"] = merge_user_with_user_from_csv(user, persons)
+            comment["state_on_creation"] = issue["state"]  # can get updated if history is retrieved
+            comment["resolution_on_creation"] = issue["resolution"]  # can get updated if history is retrieved
 
-                created = comment_x.attributes["created"].value
-                comment["changeDate"] = format_time(created)
+            created = comment_x.attributes["created"].value
+            comment["changeDate"] = format_time(created)
 
-                comment["text"] = comment_x.firstChild.data
-                comment["issueId"] = issue["id"]
-                comments.append(comment)
+            comment["text"] = comment_x.firstChild.data
+            comment["issueId"] = issue["id"]
+            comments.append(comment)
 
-            issue["comments"] = comments
+        issue["comments"] = comments
 
-            # add relations to the issue
-            relations = list()
-            for rel in issue_x.getElementsByTagName("issuelinktype"):
-                relation = dict()
-                relation["relation"] = rel.getElementsByTagName("name")[0].firstChild.data
+        # add relations to the issue
+        relations = list()
+        for rel in issue_x.getElementsByTagName("issuelinktype"):
+            relation = dict()
+            relation["relation"] = rel.getElementsByTagName("name")[0].firstChild.data
 
-                if rel.hasAttribute("inwardlinks"):
-                    left = rel.getElementsByTagName("inwardlinks")
-                    issuekeys = left.getElementsByTagName("issuekey")
-                    for key in issuekeys:
-                        relation["type"] = "inward"
-                        relation["id"] = key.firstChild.data
-                        relations.append(relation)
+            if rel.hasAttribute("inwardlinks"):
+                left = rel.getElementsByTagName("inwardlinks")
+                issuekeys = left.getElementsByTagName("issuekey")
+                for key in issuekeys:
+                    relation["type"] = "inward"
+                    relation["id"] = key.firstChild.data
+                    relations.append(relation)
 
-                if rel.hasAttribute("outwardlinks"):
-                    right = rel.getElementsByTagName("outwardlinks")
-                    issuekeys = right.getElementsByTagName("issuekey")
-                    for key in issuekeys:
-                        relation["type"] = "outward"
-                        relation["id"] = key.firstChild.data
-                        relations.append(relation)
+            if rel.hasAttribute("outwardlinks"):
+                right = rel.getElementsByTagName("outwardlinks")
+                issuekeys = right.getElementsByTagName("issuekey")
+                for key in issuekeys:
+                    relation["type"] = "outward"
+                    relation["id"] = key.firstChild.data
+                    relations.append(relation)
 
-            issue["relations"] = relations
-            issues.append(issue)
+        issue["relations"] = relations
+        issues.append(issue)
     log.debug("number of issues after parse_xml: '{}'".format(len(issues)))
     return issues
 
@@ -581,7 +583,7 @@ def print_to_disk(issues, results_folder):
             ))
 
     # write to output file
-    csv_writer.write_to_csv(output_file, lines, True)
+    csv_writer.write_to_csv(output_file, lines, append=True)
 
 
 def print_to_disk_bugs(issues, results_folder):
@@ -676,7 +678,7 @@ def print_to_disk_bugs(issues, results_folder):
                 ))
 
     # write to output file
-    csv_writer.write_to_csv(output_file, lines, True)
+    csv_writer.write_to_csv(output_file, lines, append=True)
 
 
 def print_to_disk_extr(issues, results_folder):
@@ -736,7 +738,7 @@ def print_to_disk_extr(issues, results_folder):
                 "commented"  ## event.name
             ))
     # write to output file
-    csv_writer.write_to_csv(output_file, lines, True)
+    csv_writer.write_to_csv(output_file, lines, append=True)
 
 
 def print_to_disk_gephi(issues, results_folder):
@@ -774,8 +776,8 @@ def print_to_disk_gephi(issues, results_folder):
             edge_lines.append((comment["author"]["name"], comment["id"], ["changeDate"],
                                "Person-Comment"))
     # write to output file
-    csv_writer.write_to_csv(output_file_edges, edge_lines, True)
-    csv_writer.write_to_csv(output_file_nodes, node_lines, True)
+    csv_writer.write_to_csv(output_file_edges, edge_lines, append=True)
+    csv_writer.write_to_csv(output_file_nodes, node_lines, append=True)
 
 
 def load_csv(source_folder):

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -605,7 +605,7 @@ def print_to_disk_bugs(issues, results_folder):
                 issue["author"]["email"],
                 issue["creationDate"],
                 "open",  ##  default state when created
-                "unresolved"  ## default resolution when created
+                ["unresolved"]  ## default resolution when created
             ))
 
             for comment in issue["comments"]:


### PR DESCRIPTION
The issue extraction in 'jira_issue_processing.py' now processes the xml-files successively instead as previously load and process all xml-files together. Therefore output-files get cleared at the beginning and results get appended during  the processing.
    
Signed-off-by: Anselm Fehnker <fehnker@fim.uni-passau.de>
