### PR TITLE
Adjust e-mail extraction to handle multiple mailing lists

### DIFF
--- a/codeface_extraction/codeface_extraction.py
+++ b/codeface_extraction/codeface_extraction.py
@@ -93,7 +93,7 @@ def get_parser():
 
     :return: the constructed parser
     """
-    run_parser = argparse.ArgumentParser(prog='codeface', description='Codeface extraction')
+    run_parser = argparse.ArgumentParser(prog='codeface-extraction', description='Codeface extraction')
     run_parser.add_argument('-c', '--config', help="Codeface configuration file",
                             default='codeface.conf')
     run_parser.add_argument('-p', '--project', help="Project configuration file",

--- a/codeface_extraction/extractions.py
+++ b/codeface_extraction/extractions.py
@@ -359,7 +359,7 @@ class EmailExtraction(Extraction):
         # for subclasses
         self.sql = """
                     SELECT a.name AS authorName, a.email1, m.messageId, m.creationDate, m.creationDateOffset,
-                           m.subject, m.threadId
+                           m.subject, CONCAT(m.mlId, "#", m.threadId) as threadId
 
                     FROM project p
 
@@ -373,7 +373,7 @@ class EmailExtraction(Extraction):
                     WHERE p.name = '{project}'
                     AND p.analysisMethod = '{tagging}'
 
-                    ORDER BY m.threadId, m.creationDate ASC
+                    ORDER BY threadId, m.creationDate ASC
 
                     # LIMIT 10
                 """
@@ -537,7 +537,7 @@ class EmailRangeExtraction(Extraction):
         # for subclasses
         self.sql = """
                     SELECT a.name AS authorName, a.email1, m.messageId, m.creationDate, m.creationDateOffset,
-                           m.subject, m.threadId
+                           m.subject, CONCAT(m.mlId, "#", m.threadId) as threadId
 
                     FROM project p
 
@@ -561,7 +561,7 @@ class EmailRangeExtraction(Extraction):
                     AND l2.tag = '{revision}'
                     AND m.creationDate BETWEEN l1.date AND l2.date
 
-                    ORDER BY m.threadId, m.creationDate ASC
+                    ORDER BY threadId, m.creationDate ASC
 
                     # LIMIT 10
                 """

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -50,7 +50,7 @@ known_resolutions = {"unresolved", "fixed", "wontfix", "duplicate", "invalid", "
 
 def run():
     # get all needed paths and argument for the method call.
-    parser = argparse.ArgumentParser(prog='codeface', description='Codeface extraction')
+    parser = argparse.ArgumentParser(prog='codeface-extraction-issues-github', description='Codeface extraction')
     parser.add_argument('-c', '--config', help="Codeface configuration file", default='codeface.conf')
     parser.add_argument('-p', '--project', help="Project configuration file", required=True)
     parser.add_argument('resdir', help="Directory to store analysis results in")

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -46,7 +46,7 @@ sys.setdefaultencoding("utf-8")
 
 def run():
     # get all needed paths and argument for the method call.
-    parser = argparse.ArgumentParser(prog="codeface", description="Codeface extraction")
+    parser = argparse.ArgumentParser(prog="codeface-extraction-issues-jira", description="Codeface extraction")
     parser.add_argument("-c", "--config", help="Codeface configuration file", default="codeface.conf")
     parser.add_argument("-p", "--project", help="Project configuration file", required=True)
     parser.add_argument("resdir", help="Directory to store analysis results in")

--- a/mbox_parsing/mbox_parsing.py
+++ b/mbox_parsing/mbox_parsing.py
@@ -227,7 +227,7 @@ def run():
     """Run the mbox-parsing process"""
 
     # get all needed paths and argument for the method call.
-    parser = argparse.ArgumentParser(prog='codeface', description='Codeface extraction')
+    parser = argparse.ArgumentParser(prog='codeface-extraction-mbox', description='Codeface extraction')
     parser.add_argument('-c', '--config', help="Codeface configuration file", default='codeface.conf')
     parser.add_argument('-p', '--project', help="Project configuration file", required=True)
     parser.add_argument('-f', '--filepath', help="Include the filepath in the search", action="store_true")


### PR DESCRIPTION
For the case that there are several projects configured in a Codeface
configuration, the mailing lists are stored with a unique ID but the
thread IDs of the individual e-mails are only unique to their respective
mailing list.

To circumvent the problem, the e-mail extraction (`EmailExtraction` and
`EmailRangeExtraction` classes) now construct a unique thread ID of the
following format: `{mailing-list ID}#{old thread ID}`.

Note: This does not break anything with the network library as the
thread ID (old or new, does not matter) is handled as a String constant
– what still works although the individual Strings may change for all
future extractions.