### PR TITLE
Adjusts issue extraction to the updated network library

### DIFF
--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -79,7 +79,6 @@ def run():
     issues = insert_user_data(issues, __conf)
     # 6) dump result to disk
     print_to_disk(issues, __resdir)
-    print_to_disk_new(issues, __resdir)
 
     log.info("Github issue processing complete!")
 
@@ -484,41 +483,6 @@ def print_to_disk(issues, results_folder):
 
     # construct path to output file
     output_file = os.path.join(results_folder, "issues.list")
-    log.info("Dumping output in file '{}'...".format(output_file))
-
-    # construct lines of output
-    lines = []
-    for issue in issues:
-        for event in issue["eventsList"]:
-            lines.append((
-                issue["number"],
-                issue["state"],
-                issue["created_at"],
-                issue["closed_at"],
-                issue["isPullRequest"],
-                event["user"]["name"],
-                event["user"]["email"],
-                event["created_at"],
-                "" if event["ref_target"] == "" else event["ref_target"]["name"],
-                event["event"]
-            ))
-
-    # write to output file
-    csv_writer.write_to_csv(output_file, lines)
-
-
-def print_to_disk_new(issues, results_folder):
-    """
-    Print issues to file "issues_new.list" in result folder.
-    This file has a consistent format to the "bugs-jira.list" file.
-    TODO When the network library is updated, this is the format which shall be used.
-
-    :param issues: the issues to dump
-    :param results_folder: the folder where to place "issues.list" output file
-    """
-
-    # construct path to output file
-    output_file = os.path.join(results_folder, "new_format.list")
     log.info("Dumping output in file '{}'...".format(output_file))
 
     # construct lines of output

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -15,7 +15,7 @@
 # Copyright 2017 by Raphael Nömmer <noemmer@fim.uni-passau.de>
 # Copyright 2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 # Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
-# Copyright 2018 by Anselm Fehnker <fehnker@fim.uni-passau.de>
+# Copyright 2018-2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
 # All Rights Reserved.
 """
 This file is able to extract Github issue data from json files.
@@ -392,7 +392,7 @@ def reformat_events(issue_data):
                 # "state_new" and "resolution" of the issue give the information about the state and the resolution of
                 # the issue when the comment was written, because the eventsList is sorted by time
                 event["event_info_1"] = issue["state_new"]
-                event["event_info_2"] = json.dumps(issue["resolution"])
+                event["event_info_2"] = issue["resolution"]
 
     return issue_data
 
@@ -503,7 +503,7 @@ def print_to_disk(issues, results_folder):
                 event["user"]["email"],
                 event["created_at"],
                 event["event_info_1"],
-                event["event_info_2"]
+                json.dumps(event["event_info_2"])
             ))
 
     # write to output file

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -482,7 +482,7 @@ def print_to_disk(issues, results_folder):
     """
 
     # construct path to output file
-    output_file = os.path.join(results_folder, "issues.list")
+    output_file = os.path.join(results_folder, "issues-github.list")
     log.info("Dumping output in file '{}'...".format(output_file))
 
     # construct lines of output

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -393,7 +393,7 @@ def reformat_events(issue_data):
                 # "state_new" and "resolution" of the issue give the information about the state and the resolution of
                 # the issue when the comment was written, because the eventsList is sorted by time
                 event["event_info_1"] = issue["state_new"]
-                event["event_info_2"] = str(issue["resolution"])
+                event["event_info_2"] = json.dumps(issue["resolution"])
 
     return issue_data
 
@@ -528,12 +528,12 @@ def print_to_disk_new(issues, results_folder):
             lines.append((
                 issue["number"],
                 issue["title"],
-                issue["type"],
+                json.dumps(issue["type"]),
                 issue["state_new"],
-                issue["resolution"],
+                json.dumps(issue["resolution"]),
                 issue["created_at"],
                 issue["closed_at"],
-                [],  # components
+                json.dumps([]),  # components
                 event["event"],
                 event["user"]["name"],
                 event["user"]["email"],

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -15,7 +15,7 @@
 # Copyright 2017 by Raphael Nömmer <noemmer@fim.uni-passau.de>
 # Copyright 2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 # Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
-# Copyright 2018 by Anselm Fehnker <fehnker@fim.uni-passau.de>
+# Copyright 2018-2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
 # All Rights Reserved.
 """
 This file is able to extract Jira issue data from xml files.
@@ -564,6 +564,8 @@ def print_to_disk(issues, results_folder):
     lines = []
     for issue in issues:
         log.info("Current issue '{}'".format(issue["externalId"]))
+
+        # add the creation event
         lines.append((
             issue["externalId"],
             issue["title"],
@@ -581,6 +583,7 @@ def print_to_disk(issues, results_folder):
             json.dumps(["unresolved"])  ## default resolution when created
         ))
 
+        # add an additional commented event for the creation
         lines.append((
             issue["externalId"],
             issue["title"],
@@ -598,6 +601,7 @@ def print_to_disk(issues, results_folder):
             json.dumps(["unresolved"])  ## default resolution when created
         ))
 
+        # add comment events
         for comment in issue["comments"]:
             lines.append((
                 issue["externalId"],
@@ -616,6 +620,7 @@ def print_to_disk(issues, results_folder):
                 json.dumps(comment["resolution_on_creation"])
             ))
 
+        # add history events
         for history in issue["history"]:
             lines.append((
                 issue["externalId"],
@@ -631,7 +636,7 @@ def print_to_disk(issues, results_folder):
                 history["author"]["email"],
                 history["date"],
                 history["event_info_1"],
-                history["event_info_2"]
+                json.dumps(history["event_info_2"])
             ))
 
     # write to output file
@@ -658,6 +663,8 @@ def print_to_disk_bugs(issues, results_folder):
 
         # only writes issues with type bug and their comments in the output file
         if "bug" in issue["type_list"]:
+
+            # add the creation event
             lines.append((
                 issue["externalId"],
                 issue["title"],
@@ -675,6 +682,7 @@ def print_to_disk_bugs(issues, results_folder):
                 json.dumps(["unresolved"]) ## default resolution when created
             ))
 
+            # add an additional commented event for the creation
             lines.append((
                 issue["externalId"],
                 issue["title"],
@@ -692,6 +700,7 @@ def print_to_disk_bugs(issues, results_folder):
                 json.dumps(["unresolved"])  ## default resolution when created
             ))
 
+            # add comment events
             for comment in issue["comments"]:
                 lines.append((
                     issue["externalId"],
@@ -710,6 +719,7 @@ def print_to_disk_bugs(issues, results_folder):
                     json.dumps(comment["resolution_on_creation"])
                 ))
 
+            # add history events
             for history in issue["history"]:
                 lines.append((
                     issue["externalId"],
@@ -725,7 +735,7 @@ def print_to_disk_bugs(issues, results_folder):
                     history["author"]["email"],
                     history["date"],
                     history["event_info_1"],
-                    history["event_info_2"]
+                    json.dumps(history["event_info_2"])
                 ))
 
     # write to output file

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -26,6 +26,7 @@ import os
 import sys
 import time
 import csv
+import json
 
 from xml.dom.minidom import parse
 from datetime import datetime
@@ -610,65 +611,65 @@ def print_to_disk_bugs(issues, results_folder):
             lines.append((
                 issue["externalId"],
                 issue["title"],
-                issue["type_new"],
+                json.dumps(issue["type_new"]),
                 issue["state_new"],
-                issue["resolution_new"],
+                json.dumps(issue["resolution_new"]),
                 issue["creationDate"],
                 issue["resolveDate"],
-                issue["components"],
+                json.dumps(issue["components"]),
                 "created",  ## event.name
                 issue["author"]["name"],
                 issue["author"]["email"],
                 issue["creationDate"],
                 "open",  ## default state when created
-                ["unresolved"]  ## default resolution when created
+                json.dumps(["unresolved"]) ## default resolution when created
             ))
 
             lines.append((
                 issue["externalId"],
                 issue["title"],
-                issue["type_new"],
+                json.dumps(issue["type_new"]),
                 issue["state_new"],
-                issue["resolution_new"],
+                json.dumps(issue["resolution_new"]),
                 issue["creationDate"],
                 issue["resolveDate"],
-                issue["components"],
+                json.dumps(issue["components"]),
                 "commented",
                 issue["author"]["name"],
                 issue["author"]["email"],
                 issue["creationDate"],
                 "open",  ##  default state when created
-                ["unresolved"]  ## default resolution when created
+                json.dumps(["unresolved"])  ## default resolution when created
             ))
 
             for comment in issue["comments"]:
                 lines.append((
                     issue["externalId"],
                     issue["title"],
-                    issue["type_new"],
+                    json.dumps(issue["type_new"]),
                     issue["state_new"],
-                    issue["resolution_new"],
+                    json.dumps(issue["resolution_new"]),
                     issue["creationDate"],
                     issue["resolveDate"],
-                    issue["components"],
+                    json.dumps(issue["components"]),
                     "commented",
                     comment["author"]["name"],
                     comment["author"]["email"],
                     comment["changeDate"],
                     comment["state_on_creation"],
-                    comment["resolution_on_creation"]
+                    json.dumps(comment["resolution_on_creation"])
                 ))
 
             for history in issue["history"]:
                 lines.append((
                     issue["externalId"],
                     issue["title"],
-                    issue["type_new"],
+                    json.dumps(issue["type_new"]),
                     issue["state_new"],
-                    issue["resolution_new"],
+                    json.dumps(issue["resolution_new"]),
                     issue["creationDate"],
                     issue["resolveDate"],
-                    issue["components"],
+                    json.dumps(issue["components"]),
                     history["event"],
                     history["author"]["name"],
                     history["author"]["email"],


### PR DESCRIPTION
As the network library is adjusted to the new issue data format, now also the default 'print_to_disk' methods in 'issue_extraction.py' and 'jira_issue_extraction.py' use the new issue data format. 
Also some minor changes in the new issue data format were necessary, as lists are now saved in json representation.

Signed-off-by: Anselm Fehnker <fehnker@fim.uni-passau.de>