### PR TITLE
Retrieve all search results of the mbox parsing without limit

### DIFF
--- a/mbox_parsing/mbox_parsing.py
+++ b/mbox_parsing/mbox_parsing.py
@@ -164,7 +164,7 @@ def __parse_execute(artifact, schema, my_index, include_filepath):
             my_query = query_parser.parse("\"%s\"" % artifact[1])
 
         # search!
-        query_result = searcher.search(my_query, terms=True, optimize=False)
+        query_result = searcher.search(my_query, terms=True, optimize=False, limit=None)
 
         # construct result from query answer
         for r in query_result:


### PR DESCRIPTION
The whoosh searcher has a default limit of 10 results per search query.
As we want to retrieve all results, which can be more than 10 per query,
we need to explicitly set the limit to `None`.