### PR TITLE
Improve extraction of GitHub issue data

### DIFF
--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -389,6 +389,11 @@ def merge_issue_events(issue_data):
                         review["state"] = review["event_info_1"] = event["state"]
                         review["event_info_2"] = "later_dismissed"
 
+            # if event is assign event, we have set the user to the assigner and the ref target to the assignee
+            if event["event"] == "assigned":
+                event["ref_target"] = event["user"]
+                event["user"] = event["assigner"]
+
         # merge events, relatedCommits, relatedIssues and comment lists
         issue["eventsList"] = issue["commentsList"] + issue["eventsList"] + issue["relatedIssues"] + issue[
             "relatedCommits"] + issue["reviewsList"]

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -241,17 +241,16 @@ def merge_issue_events(issue_data):
         issue["eventsList"].append(created_event)
         issue["state_new"] = "open"
 
-        # if the creation event contains a comment, add it to the list of comments
-        if not issue["body"] is None and not issue["body"] == "":
-            creationComment = dict()
-            creationComment["event"] = "commented"
-            creationComment["user"] = issue["user"]
-            creationComment["referenced_at"] = issue["created_at"]
-            creationComment["ref_target"] = ""
-            creationComment["event_info_1"] = ""
-            creationComment["event_info_2"] = ""
+        # adds commented event for the creation-event comment to the commentsList
+        creationComment = dict()
+        creationComment["event"] = "commented"
+        creationComment["user"] = issue["user"]
+        creationComment["referenced_at"] = issue["created_at"]
+        creationComment["ref_target"] = ""
+        creationComment["event_info_1"] = ""
+        creationComment["event_info_2"] = ""
 
-            issue["commentsList"].append(creationComment)
+        issue["commentsList"].append(creationComment)
 
         # the format of every related issue is adjusted to the event format
         for rel_issue in issue["relatedIssues"]:

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -479,6 +479,18 @@ def reformat_events(issue_data):
                 if user["email"] is None or user["email"] == "":
                     user["email"] = event["user"]["email"]
 
+            # 3) add or update users which are ref_target of the current event
+            if not event["ref_target"] is None and not event["ref_target"] == "":
+                if not event["ref_target"]["username"] in users.keys():
+                    if not event["ref_target"]["username"] is None and not event["ref_target"]["username"] == "":
+                        users[event["ref_target"]["username"]] = event["ref_target"]
+                else:
+                    user = users[event["ref_target"]["username"]]
+                    if user["name"] is None or user["name"] == "":
+                        user["name"] = event["user"]["name"]
+                    if user["email"] is None or user["email"] == "":
+                        user["email"] = event["user"]["email"]
+
     # as the user dictionary is created, start re-formating the event information of all issues
     for issue in issue_data:
 

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -239,11 +239,10 @@ def merge_issue_events(issue_data):
         # the format of every related commit is adjusted to the event format
         for rel_commit in issue["relatedCommits"]:
 
-            # if the related commit has no time, it is a commit in the pull-request
-            if rel_commit["referenced_at"] is None:
-                rel_commit["user"] = create_user("", "", "")
-                rel_commit["created_at"] = ""
-                rel_commit["event"] = "has_commit"
+            # if the related commit has no user name, it is a commit which was added to the pull request
+            if rel_commit["user"]["username"] is None or rel_commit["user"]["username"] == "":
+                rel_commit["created_at"] = format_time(rel_commit["referenced_at"])
+                rel_commit["event"] = "commit_added"
                 rel_commit["event_info_1"] = rel_commit["commit_id"]
                 rel_commit["event_info_2"] = ""
                 rel_commit["ref_target"] = ""

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -492,9 +492,9 @@ def reformat_events(issue_data):
                 else:
                     user = users[event["ref_target"]["username"]]
                     if user["name"] is None or user["name"] == "":
-                        user["name"] = event["user"]["name"]
+                        user["name"] = event["ref_target"]["name"]
                     if user["email"] is None or user["email"] == "":
-                        user["email"] = event["user"]["email"]
+                        user["email"] = event["ref_target"]["email"]
 
     # as the user dictionary is created, start re-formating the event information of all issues
     for issue in issue_data:

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -379,7 +379,7 @@ def merge_issue_events(issue_data):
                 event["user"]["username"] = event["commit"]["author"]["username"]
 
             # if event is a review request, we can update the ref target with the requested reviewer
-            if event["event"] == "review_requested":
+            if event["event"] == "review_requested" or event["event"] == "review_request_removed":
                 event["ref_target"] = event["requestedReviewer"]
 
             # if event dismisses a review, we can determine the original state of the corresponding review
@@ -390,7 +390,7 @@ def merge_issue_events(issue_data):
                         review["event_info_2"] = "later_dismissed"
 
             # if event is assign event, we have set the user to the assigner and the ref target to the assignee
-            if event["event"] == "assigned":
+            if event["event"] == "assigned" or event["event"] == "unassigned":
                 event["ref_target"] = event["user"]
                 event["user"] = event["assigner"]
 

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -517,6 +517,8 @@ def reformat_events(issue_data):
     # as the user dictionary is created, start re-formating the event information of all issues
     for issue in issue_data:
 
+        events_to_remove = list()
+
         # re-format information of every event in the eventsList of an issue
         for event in issue["eventsList"]:
 
@@ -588,7 +590,7 @@ def reformat_events(issue_data):
                     type_event["ref_target"] = ""
                     issue["eventsList"].append(type_event)
 
-                    # if the label is in this list, it also is a resolution of the issue
+                # if the label is in this list, it also is a resolution of the issue
                 elif label in known_resolutions:
                     issue["resolution"].remove(str(label))
 
@@ -608,8 +610,17 @@ def reformat_events(issue_data):
                 event["event_info_1"] = issue["state_new"]
                 event["event_info_2"] = issue["resolution"]
 
+            elif event["event"] == "referenced" and not event["commit"] is None:
+                # remove "referenced" events originating from commits
+                # as they are handled as referenced commit
+                events_to_remove.append(event)
+
         # sorts eventsList by time again
         issue["eventsList"] = sorted(issue["eventsList"], key=lambda k: k["created_at"])
+
+        # remove unwanted events
+        for event_to_remove in events_to_remove:
+            issue["eventsList"].remove(event_to_remove)
 
     return issue_data
 

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -375,9 +375,9 @@ def reformat_events(issue_data):
 
     log.info("Update event information ...")
 
-    for issue in issue_data:
+    users = dict()
 
-        users = dict()
+    for issue in issue_data:
 
         for event in issue["eventsList"]:
 
@@ -390,6 +390,7 @@ def reformat_events(issue_data):
                     user["name"] = event["user"]["name"]
                 if user["email"] is None or user["email"] == "":
                     user["email"] = event["user"]["email"]
+    for issue in issue_data:
 
         # re-format information of every event in the eventsList of an issue
         for event in issue["eventsList"]:

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -602,4 +602,4 @@ def print_to_disk(issues, results_folder):
             ))
 
     # write to output file
-    csv_writer.write_to_csv(output_file, lines)
+    csv_writer.write_to_csv(output_file, sorted(set(lines), key=lambda line: lines.index(line)))

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -583,7 +583,8 @@ def reformat_events(issue_data):
 
                 # if the label is in this list, it also is a type of the issue
                 if label in known_types:
-                    issue["type"].remove(str(label))
+                    if label in issue["type"]:
+                        issue["type"].remove(str(label))
 
                     # creates an event for type updates and adds it to the eventsList
                     type_event = dict()
@@ -597,7 +598,8 @@ def reformat_events(issue_data):
 
                 # if the label is in this list, it also is a resolution of the issue
                 elif label in known_resolutions:
-                    issue["resolution"].remove(str(label))
+                    if label in issue["resolution"]:
+                        issue["resolution"].remove(str(label))
 
                     # creates an event for resolution updates and adds it to the eventsList
                     resolution_event = dict()

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -16,6 +16,7 @@
 # Copyright 2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 # Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
 # Copyright 2018-2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
+# Copyright 2019 by Thomas Bock <bockthom@fim.uni-passau.de>
 # All Rights Reserved.
 """
 This file is able to extract Github issue data from json files.

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -446,6 +446,8 @@ def merge_issue_events(issue_data):
 
             # if event is a referenced commit, we can update the user information
             if event["event"] == "referenced" and event["commit"] is not None:
+                if (event["user"] is None):
+                    event["user"] = dict()
                 event["user"]["name"] = event["commit"]["author"]["name"] # author or committer?
                 event["user"]["email"] = event["commit"]["author"]["email"]
                 event["user"]["username"] = event["commit"]["author"]["username"]

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -347,6 +347,10 @@ def merge_issue_events(issue_data):
                 event["user"]["email"] = event["commit"]["author"]["email"]
                 event["user"]["username"] = event["commit"]["author"]["username"]
 
+            # if event is a review request, we can update the ref target with the requested reviewer
+            if event["event"] == "review_requested":
+                event["ref_target"] = event["requestedReviewer"]
+
         # merge events, relatedCommits, relatedIssues and comment lists
         issue["eventsList"] = issue["commentsList"] + issue["eventsList"] + issue["relatedIssues"] + issue[
             "relatedCommits"] + issue["reviewsList"]

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -174,7 +174,9 @@ def lookup_user(user_dict, user):
     if (user["name"] == "" or user["name"] is None or
         user["email"] is None or user["email"] == ""):
 
-        user = user_dict[user["username"]]
+        # lookup user only if username is not None and not empty
+        if not user["username"] is None and not user["username"] == "":
+            user = user_dict[user["username"]]
 
     return user
 

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -276,17 +276,18 @@ def merge_issue_events(issue_data):
             review["ref_target"] = ""
 
             if review["hasReviewInitialComment"]:
-                comment["event"] = "commented"
-                comment["user"] = review["user"]
-                comment["ref_target"] = ""
-                comment["created_at"] = format_time(review["submitted_at"])
-                comment["event_info_1"] = ""
-                comment["event_info_2"] = ""
+                initialComment = dict()
+                initialComment["event"] = "commented"
+                initialComment["user"] = review["user"]
+                initialComment["ref_target"] = ""
+                initialComment["created_at"] = format_time(review["submitted_at"])
+                initialComment["event_info_1"] = ""
+                initialComment["event_info_2"] = ""
 
-                issue["commentsList"].append(comment)
+                issue["commentsList"].append(initialComment)
 
                 # cache comment by date to resolve/re-arrange references later
-                comments[comment["created_at"]] = comment
+                comments[initialComment["created_at"]] = initialComment
 
             for reviewComment in review["reviewComments"]:
                 reviewComment["event"] = "commented"

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -252,8 +252,9 @@ def merge_issue_events(issue_data):
         # the format of every related commit is adjusted to the event format
         for rel_commit in issue["relatedCommits"]:
 
-            # if the related commit has no user name, it is a commit which was added to the pull request
-            if rel_commit["user"]["username"] is None or rel_commit["user"]["username"] == "":
+            # if the related commit is not of type "commit" but "commitAddedToPullRequest",
+            # it is a commit which was added to the pull request
+            if rel_commit["type"] == "commitAddedToPullRequest":
                 rel_commit["created_at"] = format_time(rel_commit["referenced_at"])
                 rel_commit["event"] = "commit_added"
                 rel_commit["event_info_1"] = rel_commit["commit_id"]
@@ -382,7 +383,7 @@ def reformat_events(issue_data):
         for event in issue["eventsList"]:
 
             if not event["user"]["username"] in users.keys():
-                if not event["user"]["username"] is None or event["user"]["username"] == "":
+                if not event["user"]["username"] is None and not event["user"]["username"] == "":
                     users[event["user"]["username"]] = event["user"]
             else:
                 user = users[event["user"]["username"]]

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -241,6 +241,18 @@ def merge_issue_events(issue_data):
         issue["eventsList"].append(created_event)
         issue["state_new"] = "open"
 
+        # if the creation event contains a comment, add it to the list of comments
+        if not issue["body"] is None and not issue["body"] == "":
+            creationComment = dict()
+            creationComment["event"] = "commented"
+            creationComment["user"] = issue["user"]
+            creationComment["referenced_at"] = issue["created_at"]
+            creationComment["ref_target"] = ""
+            creationComment["event_info_1"] = ""
+            creationComment["event_info_2"] = ""
+
+            issue["commentsList"].append(creationComment)
+
         # the format of every related issue is adjusted to the event format
         for rel_issue in issue["relatedIssues"]:
             rel_issue["created_at"] = format_time(rel_issue["referenced_at"])

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -327,6 +327,24 @@ def merge_issue_events(issue_data):
 
                 issue["commentsList"].append(reviewComment)
 
+        # add dismissal comments to the list of comments
+        for event in issue["eventsList"]:
+
+            if (event["event"] == "review_dismissed" and not event["dismissalMessage"] is None
+               and not event["dismissalMessage"] == ""):
+                dismissalComment = dict()
+                dismissalComment["event"] = "commented"
+                dismissalComment["user"] = event["user"]
+                dismissalComment["created_at"] = format_time(event["created_at"])
+                dismissalComment["ref_target"] = ""
+                dismissalComment["event_info_1"] = ""
+                dismissalComment["event_info_2"] = ""
+
+                # cache comment by date to resolve/re-arrange references later
+                comments[dismissalComment["created_at"]] = dismissalComment
+
+                issue["commentsList"].append(dismissalComment)
+
         # the format of every event is adjusted
         for event in issue["eventsList"]:
             event["ref_target"] = ""
@@ -371,19 +389,6 @@ def merge_issue_events(issue_data):
                         review["state"] = review["event_info_1"] = event["state"]
                         review["event_info_2"] = "later_dismissed"
 
-                if not event["dismissalMessage"] is None and not event["dismissalMessage"] == "":
-                    dismissalComment = dict()
-                    dismissalComment["event"] = "commented"
-                    dismissalComment["user"] = event["user"]
-                    dismissalComment["created_at"] = format_time(event["created_at"])
-                    dismissalComment["ref_target"] = ""
-                    dismissalComment["event_info_1"] = ""
-                    dismissalComment["event_info_2"] = ""
-
-                    # cache comment by date to resolve/re-arrange references later
-                    comments[dismissalComment["created_at"]] = dismissalComment
-
-                    issue["commentsList"].append(dismissalComment)
         # merge events, relatedCommits, relatedIssues and comment lists
         issue["eventsList"] = issue["commentsList"] + issue["eventsList"] + issue["relatedIssues"] + issue[
             "relatedCommits"] + issue["reviewsList"]

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -352,8 +352,33 @@ def reformat_events(issue_data):
 
     for issue in issue_data:
 
+        users = dict()
+
+        for event in issue["eventsList"]:
+
+            if not event["user"]["username"] in users.keys():
+                if not event["user"]["username"] is None or event["user"]["username"] == "":
+                    users[event["user"]["username"]] = event["user"]
+            else:
+                user = users[event["user"]["username"]]
+                if user["name"] is None or user["name"] == "":
+                    user["name"] = event["user"]["name"]
+                if user["email"] is None or user["email"] == "":
+                    user["email"] = event["user"]["email"]
+
         # re-format information of every event in the eventsList of an issue
         for event in issue["eventsList"]:
+
+            if (event["user"]["name"] == "" or event["user"]["name"] is None or
+                event["user"]["email"] is None or event["user"]["email"] == ""):
+
+                event["user"] = users[event["user"]["username"]]
+
+            if (event["ref_target"] != "" and
+                (event["ref_target"]["name"] == "" or event["ref_target"]["name"] is None or
+                 event["ref_target"]["email"] is None or event["ref_target"]["email"] == ""
+                )):
+                event["ref_target"] = users[event["ref_target"]["username"]]
 
             if event["event"] == "closed":
                 event["event"] = "state_updated"

--- a/mbox_parsing/mbox_parsing.py
+++ b/mbox_parsing/mbox_parsing.py
@@ -14,7 +14,7 @@
 #
 # Copyright 2017 by Raphael Nömmer <noemmer@fim.uni-passau.de>
 # Copyright 2017-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
-# Copyright 2018 by Thomas Bock <bockthom@fim.uni-passau.de>
+# Copyright 2018-2019 by Thomas Bock <bockthom@fim.uni-passau.de>
 # All Rights Reserved.
 """
 This file is able to extract artifact occurrences in e-mail within mbox files.

--- a/mbox_parsing/mbox_parsing.py
+++ b/mbox_parsing/mbox_parsing.py
@@ -123,11 +123,11 @@ def __mbox_getbody(message):
         for part in message.walk():
             if part.is_multipart():
                 for subpart in part.walk():
-                    if __text_indicator in subpart.get_content_type():
+                    if __text_indicator in subpart.get_content_type().lower():
                         body = subpart.get_payload(decode=True)
-            elif __text_indicator in part.get_content_type():
+            elif __text_indicator in part.get_content_type().lower():
                 body = part.get_payload(decode=True)
-    elif __text_indicator in message.get_content_type():
+    elif __text_indicator in message.get_content_type().lower():
         body = message.get_payload(decode=True)
 
     if body is None:


### PR DESCRIPTION
In this pull request, I add lots of improvements and take of more consistency of the issue data.

This pull request is related to se-passau/GitHubWrapper#25.
This pull request should only be merged as far as se-passau/GitHubWrapper#25 is approved, at least (or merged in the end).

Here are the main enhancements:

- Add review data, review comments, review requests, review dismiss events [94bab3a, 4eb6e20, 
b4283f9, 3862355, 16debcf]
- Unify GitHub users, that is, bring usernames and name/e-mail of commits together [9370972, 
973e2b9, 1faf340, 47e3ec8, 6adb906]
- Fix and enhance information for "assigned", "unassigned", "mentioned", "subscribed" events [
622b7f8, 8d66e45, b135036]
- Distinguish related commits in "add_link", "comitt_added", and "referenced_by" [39ff302, 2254fb9, 2b5e72b, 5602a7f ]
- Add a reversed event for referencing issues, that is, "referencedy_by" as opposite of "add_link" [c34842a, 2b5e72b]
- Remove duplicated events [b9a7182]
- Automatically add a "commented" event for each "created" event [18a65da, 066d875]

As soon as my enhancements are approved, I will upload an updated version of the diagram which shows all the events and their possible fields.

Please let me know if you have any suggestions on how to further improve the issue data.