### PR TITLE
Fix undefined variable in 'CommitRangeExtraction'

### DIFF
--- a/codeface_extraction/extractions.py
+++ b/codeface_extraction/extractions.py
@@ -520,7 +520,7 @@ class CommitRangeExtraction(Extraction):
     def _reduce_result(self, result):
         # fix name encoding
         return [(id, authorDate, fix_name_encoding(authorName), authorEmail,
-                 committerDate, fix_name_encoding(committerName), committerEmail,
+                 commitDate, fix_name_encoding(committerName), committerEmail,
                  commitHash, changedFiles, addedLines, deletedLines, diffSize,
                  file, entityId, entityType, size)
                 for (id, authorDate, authorName, authorEmail,


### PR DESCRIPTION
The variable `committerDate` is not defined in the context of `CommitRangeExtraction::_reduce_result`. When enabling `--range` in the CLI, an error is produced and the extraction crashes. This is a regression introduced by commit d95967f7e18b367359d417fc3cdb51f08a04a85b and which has been missed in the review for PR #23.

The mistake is fixed by accessing the wanted variable `commitDate`.