### PR TITLE
Retrieve each commit only once in the commit extraction

### DIFF
--- a/codeface_extraction/extractions.py
+++ b/codeface_extraction/extractions.py
@@ -14,6 +14,7 @@
 #
 # Copyright 2015-2018 by Claus Hunsen <hunsen@fim.uni-passau.de>
 # Copyright 2016, 2018-2019 by Thomas Bock <bockthom@fim.uni-passau.de>
+# Copyright 2019 by Thomas Bock <bockthom@cs.uni-saarland.de>
 # Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
 # Copyright 2018 by Tina Schuh <schuht@fim.uni-passau.de>
 # All Rights Reserved.
@@ -265,7 +266,7 @@ class CommitExtraction(Extraction):
 
         # for subclasses
         self.sql = """
-                    SELECT c.id,
+                    SELECT MIN(c.id),
                            c.authorDate, a.name, a.email1,
                            c.commitDate, acom.name, acom.email1,
                            c.commitHash, c.ChangedFiles, c.AddedLines, c.DeletedLines, c.DiffSize,
@@ -288,6 +289,9 @@ class CommitExtraction(Extraction):
                     # filter for current project
                     WHERE p.name = '{project}'
                     AND p.analysisMethod = '{tagging}'
+
+                    # filter duplicated commits
+                    GROUP BY c.commitHash, cd.file, cd.entityId, cd.entityType
 
                     ORDER BY c.authorDate, a.name, c.id, cd.file, cd.entityId
 

--- a/codeface_extraction/extractions.py
+++ b/codeface_extraction/extractions.py
@@ -638,6 +638,20 @@ class EmailRangeExtraction(Extraction):
                     AND l2.tag = '{revision}'
                     AND m.creationDate BETWEEN l1.date AND l2.date
 
+                    # remove e-mails from previous range
+                    AND m.messageId NOT IN (SELECT m2.messageId
+                                            FROM project p
+                                            JOIN release_range r0 ON r0.projectId = p.id
+                                            JOIN release_range r1 ON r1.projectId = p.id
+                                            JOIN release_timeline l0 ON r0.releaseStartId = l0.id
+                                            JOIN release_timeline l1 ON r0.releaseEndId = l1.id
+                                            JOIN release_timeline l2 ON r1.releaseEndId = l2.id
+                                            JOIN mail m2 ON m2.creationDate BETWEEN l0.date AND l1.date
+                                            WHERE l2.tag = '{revision}'
+                                            AND r0.releaseEndId = r1.releaseStartId
+                                            AND p.name = '{project}'
+                                            AND p.analysisMethod = '{tagging}' )
+
                     ORDER BY threadId, m.creationDate ASC
 
                     # LIMIT 10

--- a/codeface_extraction/extractions.py
+++ b/codeface_extraction/extractions.py
@@ -516,6 +516,19 @@ class CommitRangeExtraction(Extraction):
                     AND p.analysisMethod = '{tagging}'
                     AND l2.tag = '{revision}'
 
+                    # remove commits from previous range
+                    AND c.commitHash NOT IN (SELECT c2.commitHash
+                                             FROM project p
+                                             JOIN release_range r0 ON r0.projectId = p.id
+                                             JOIN release_range r1 ON r1.projectId = p.id
+                                             JOIN release_timeline l0 ON r0.releaseEndId = l0.id
+                                             JOIN release_timeline l2 ON r1.releaseEndId = l2.id
+                                             JOIN commit c2 ON r0.id = c2.releaseRangeId
+                                             WHERE l2.tag = '{revision}'
+                                             AND r0.releaseEndId = r1.releaseStartId
+                                             AND p.name = '{project}'
+                                             AND p.analysisMethod = '{tagging}' )
+
                     ORDER BY c.authorDate, a.name, c.id, cd.file, cd.entityId
 
                     # LIMIT 10

--- a/codeface_extraction/extractions.py
+++ b/codeface_extraction/extractions.py
@@ -522,12 +522,11 @@ class CommitRangeExtraction(Extraction):
                     AND p.analysisMethod = '{tagging}'
                     AND l2.tag = '{revision}'
 
-                    # remove commits from previous range
+                    # remove commits from previous range (each range includes its end)
                     AND c.commitHash NOT IN (SELECT c2.commitHash
                                              FROM project p
                                              JOIN release_range r0 ON r0.projectId = p.id
                                              JOIN release_range r1 ON r1.projectId = p.id
-                                             JOIN release_timeline l0 ON r0.releaseEndId = l0.id
                                              JOIN release_timeline l2 ON r1.releaseEndId = l2.id
                                              JOIN commit c2 ON r0.id = c2.releaseRangeId
                                              WHERE l2.tag = '{revision}'
@@ -581,12 +580,11 @@ class CommitMessageRangeExtraction(Extraction):
                     AND p.analysisMethod = '{tagging}'
                     AND l2.tag = '{revision}'
 
-                    # remove commits from previous range
+                    # remove commits from previous range (each range includes its end)
                     AND c.commitHash NOT IN (SELECT c2.commitHash
                                              FROM project p
                                              JOIN release_range r0 ON r0.projectId = p.id
                                              JOIN release_range r1 ON r1.projectId = p.id
-                                             JOIN release_timeline l0 ON r0.releaseEndId = l0.id
                                              JOIN release_timeline l2 ON r1.releaseEndId = l2.id
                                              JOIN commit c2 ON r0.id = c2.releaseRangeId
                                              WHERE l2.tag = '{revision}'
@@ -638,7 +636,7 @@ class EmailRangeExtraction(Extraction):
                     AND l2.tag = '{revision}'
                     AND m.creationDate BETWEEN l1.date AND l2.date
 
-                    # remove e-mails from previous range
+                    # remove e-mails from previous range (each range includes its end)
                     AND m.messageId NOT IN (SELECT m2.messageId
                                             FROM project p
                                             JOIN release_range r0 ON r0.projectId = p.id
@@ -698,12 +696,11 @@ class FunctionImplementationRangeExtraction(Extraction):
                     AND l2.tag = '{revision}'
                     AND cd.file IS NOT NULL
 
-                    # remove commits from previous range
+                    # remove commits from previous range (each range includes its end)
                     AND c.commitHash NOT IN (SELECT c2.commitHash
                                              FROM project p
                                              JOIN release_range r0 ON r0.projectId = p.id
                                              JOIN release_range r1 ON r1.projectId = p.id
-                                             JOIN release_timeline l0 ON r0.releaseEndId = l0.id
                                              JOIN release_timeline l2 ON r1.releaseEndId = l2.id
                                              JOIN commit c2 ON r0.id = c2.releaseRangeId
                                              WHERE l2.tag = '{revision}'


### PR DESCRIPTION
As Codeface analyzes the data in three-month ranges, commits which are
on the border of those ranges are included twice as they belong to two
different ranges and, therefore, end up with two different commit ids in
the database though having the same commit hash.

(It is not enough to only filter those commits based on the commit
hashes describing the start or end of a Codeface range. The reason for
that is that Codeface assigns commits to a range not based on the commit
hash describing the start/end of a range, but on the commit date (not
the author date) of the belonging to the commit hash which desribes the
start/end. Hence, all those commits which have the same commit date or
also assigned to both ranges!)

To mitigate this, only extract such commits once, that is, just take the
entries having the lower commit id of those commits having the same
hashes.

(It is not necessary to adjust the range extraction as within each
range, each commit appears already only once. However, keep in mind that
when combining all the range extractions, the commits at the border will
still be duplicated.)

This fixes #28.