### PR TITLE
Fix empty name string in JIRA issue processing

### DIFF
--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -503,7 +503,7 @@ def insert_user_data(issues, conf):
 
     def get_or_update_user(user, buffer_db=user_buffer):
         # fix encoding for name and e-mail address
-        if user["name"] is not None:
+        if user["name"] is not None and user["name"] != "":
             name = unicode(user["name"]).encode("utf-8")
         else:
             name = unicode(user["username"]).encode("utf-8")


### PR DESCRIPTION
When processing JIRA issues, it is possible that we cannot extract a name of
a developer from JIRA, but only a username. In such a case, the 'name' is
set to the empty string. However, when searching for the user in the
database, we only check for the name. If the name is an empty string,
the id-service of Codeface treats this as NULL and, therefore, a person with
name NULL is added to the Codeface database. When extracting the date from
the database via codeface-extraction afterwards, this leads to an error as a
name NULL (None) cannot be processed.

To fix this, enhance the check whether a user's name is None by also checking
for an empty name and set the name to the user's username then.