### PR TITLE
Add a script for postprocessing author data

### DIFF
--- a/author_postprocessing/__init__.py
+++ b/author_postprocessing/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -87,111 +87,111 @@ def run_postprocessing(conf, resdir):
         if authors_list in filenames:
             f = path.join(filepath, authors_list)
             log.info("Postprocess %s ...", f)
-            authors = csv_writer.read_from_csv(f)
+            author_data = csv_writer.read_from_csv(f)
 
-            authors_to_remove = []
-            authors_new = []
+            author_data_to_remove = []
+            author_data_new = []
 
             # get persons which should be removed
             for person in disambiguation_data:
-                authors_to_remove.append([person[3], person[4], person[5]])
+                author_data_to_remove.append([person[3], person[4], person[5]])
 
-            for author in authors:
+            for author in author_data:
                 # keep author entry only if it should not be removed
-                if not author in authors_to_remove:
-                    authors_new.append(author)
-            csv_writer.write_to_csv(f, authors_new)
+                if not author in author_data_to_remove:
+                    author_data_new.append(author)
+            csv_writer.write_to_csv(f, author_data_new)
 
         # (2) Adjust commits lists
         if commits_list in filenames:
             f = path.join(filepath, commits_list)
             log.info("Postprocess %s ...", f)
-            authors = csv_writer.read_from_csv(f)
+            commit_data = csv_writer.read_from_csv(f)
 
             for person in disambiguation_data:
-                for author in authors:
+                for commit in commit_data:
                     # replace author if necessary
-                    if person[4] == author[2] and person[5] == author[3]:
-                        author[2] = person[1]
-                        author[3] = person[2]
+                    if person[4] == commit[2] and person[5] == commit[3]:
+                        commit[2] = person[1]
+                        commit[3] = person[2]
                     # replace committer if necessary
-                    if person[4] == author[5] and person[5] == author[6]:
-                        author[5] = person[1]
-                        author[6] = person[2]
+                    if person[4] == commit[5] and person[5] == commit[6]:
+                        commit[5] = person[1]
+                        commit[6] = person[2]
 
-            csv_writer.write_to_csv(f, authors)
+            csv_writer.write_to_csv(f, commit_data)
 
         # (3) Adjust emails lists
         if emails_list in filenames:
             f = path.join(filepath, emails_list)
             log.info("Postprocess %s ...", f)
-            authors = csv_writer.read_from_csv(f)
+            email_data = csv_writer.read_from_csv(f)
 
             for person in disambiguation_data:
-                for author in authors:
+                for email in email_data:
                     # replace author if necessary
-                    if person[4] == author[0] and person[5] == author[1]:
-                        author[0] = person[1]
-                        author[1] = person[2]
+                    if person[4] == email[0] and person[5] == email[1]:
+                        email[0] = person[1]
+                        email[1] = person[2]
 
-            csv_writer.write_to_csv(f, authors)
+            csv_writer.write_to_csv(f, email_data)
 
         # (4) Adjust issues lists (github)
         if issues_github_list in filenames:
             f = path.join(filepath, issues_github_list)
             log.info("Postprocess %s ...", f)
-            authors = csv_writer.read_from_csv(f)
+            issue_data = csv_writer.read_from_csv(f)
 
             for person in disambiguation_data:
-                for author in authors:
+                for issue_event in issue_data:
                     # replace author if necessary
-                    if person[4] == author[9] and person[5] == author[10]:
-                        author[9] = person[1]
-                        author[10] = person[2]
+                    if person[4] == issue_event[9] and person[5] == issue_event[10]:
+                        issue_event[9] = person[1]
+                        issue_event[10] = person[2]
                     # replace person in event info 1/2 if necessary
-                    if person[4] == author[12] and person[5] == author[13]:
-                        author[12] = person[1]
-                        author[13] = person[2]
+                    if person[4] == issue_event[12] and person[5] == issue_event[13]:
+                        issue_event[12] = person[1]
+                        issue_event[13] = person[2]
 
-            csv_writer.write_to_csv(f, authors)
+            csv_writer.write_to_csv(f, issue_data)
 
         # (5) Adjust issues lists (jira)
         if issues_jira_list in filenames:
             f = path.join(filepath, issues_jira_list)
             log.info("Postprocess %s ...", f)
-            authors = csv_writer.read_from_csv(f)
+            issue_data = csv_writer.read_from_csv(f)
 
             for person in disambiguation_data:
-                for author in authors:
+                for issue_event in issue_data:
                     # replace author if necessary
-                    if person[4] == author[9] and person[5] == author[10]:
-                        author[9] = person[1]
-                        author[10] = person[2]
+                    if person[4] == issue_event[9] and person[5] == issue_event[10]:
+                        issue_event[9] = person[1]
+                        issue_event[10] = person[2]
                     # replace person in event info 1/2 if necessary
-                    if person[4] == author[12] and person[5] == author[13]:
-                        author[12] = person[1]
-                        author[13] = person[2]
+                    if person[4] == issue_event[12] and person[5] == issue_event[13]:
+                        issue_event[12] = person[1]
+                        issue_event[13] = person[2]
 
-            csv_writer.write_to_csv(f, authors)
+            csv_writer.write_to_csv(f, issue_data)
 
         # (6) Adjust bugs lists (jira)
         if bugs_jira_list in filenames:
             f = path.join(filepath, bugs_jira_list)
             log.info("Postprocess %s ...", f)
-            authors = csv_writer.read_from_csv(f)
+            bug_data = csv_writer.read_from_csv(f)
 
             for person in disambiguation_data:
-                for author in authors:
+                for bug_event in bug_data:
                     # replace author if necessary
-                    if person[4] == author[9] and person[5] == author[10]:
-                        author[9] = person[1]
-                        author[10] = person[2]
+                    if person[4] == bug_event[9] and person[5] == bug_event[10]:
+                        bug_event[9] = person[1]
+                        bug_event[10] = person[2]
                     # replace person in event info 1/2 if necessary
-                    if person[4] == author[12] and person[5] == author[13]:
-                        author[12] = person[1]
-                        author[13] = person[2]
+                    if person[4] == bug_event[12] and person[5] == bug_event[13]:
+                        bug_event[12] = person[1]
+                        bug_event[13] = person[2]
 
-            csv.writer.write_to_csv(f, authors)
+            csv.writer.write_to_csv(f, bug_data)
 
     log.info("Postprocessing complete!")
 

--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -1,0 +1,217 @@
+# coding=utf-8
+# This file is part of codeface-extraction, which is free software: you
+# can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2015-2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
+# Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
+# All Rights Reserved.
+"""
+This file is able to disambiguate authors after the extraction from the Codeface database was performed. A manually created disambiguation file is used to disambiguate the authors in all the extracted files of a project.
+"""
+
+import argparse
+import sys
+from os import path, walk
+from os.path import abspath
+
+from codeface.cli import log
+from codeface.configuration import Configuration
+from codeface.dbmanager import DBManager
+
+from csv_writer import csv_writer
+
+
+##
+# RUN POSTPROCESSING
+##
+
+
+def run_postprocessing(conf, resdir):
+    """
+    Runs the postprocessing for the given parameters, that is, read the disambiguation file of the project
+    and replace all author names and e-mail addresses in all other .list files according to the disambiguation file
+
+    :param conf: the Codeface configuration object
+    :param resdir: the Codeface results dir, where output files are written
+    """
+
+    log.info("%s: Postprocess authors after manual disambiguation" % conf["project"])
+
+    authors_list = "authors.list"
+    commits_list = "commits.list"
+    emails_list = "emails.list"
+    issues_github_list = "issues-github.lisst"
+    issues_jira_list = "issues-jira.list"
+    bugs_jira_list = "bugs-jira.list"
+
+    disambiguation_list = path.join(resdir, conf["project"], conf["tagging"], "disambiguation-after-db.list")
+
+    # Check if a disambiguation list exists - if not, just stop
+    if path.exists(disambiguation_list):
+        disambiguation_data = csv_writer.read_from_csv(disambiguation_list)
+    else:
+        log.info("Disambiguation file does not exist: %s", disambiguation_list)
+        log.info("No postprocessing performed!")
+        return
+
+    # Check for all files in the result directory of the project whether they need to be adjusted
+    for filepath, dirnames, filenames in walk(path.join(resdir, conf["project"], conf["tagging"])):
+        
+        # (1) Adjust authors lists
+        if authors_list in filenames:
+            f = path.join(filepath, authors_list)
+            log.info("Postprocess %s ...", f)
+            authors = csv_writer.read_from_csv(f)
+
+            authors_to_remove = []
+            authors_new = []
+
+            # get persons which should be removed
+            for person in disambiguation_data:
+                authors_to_remove.append([person[3], person[4], person[5]])
+
+            for author in authors:
+                # keep author entry only if it should not be removed
+                if not author in authors_to_remove:
+                    authors_new.append(author)
+            csv_writer.write_to_csv(f, authors_new)
+
+        # (2) Adjust commits lists
+        if commits_list in filenames:
+            f = path.join(filepath, commits_list)
+            log.info("Postprocess %s ...", f)
+            authors = csv_writer.read_from_csv(f)
+
+            for person in disambiguation_data:
+                for author in authors:
+                    # replace author if necessary
+                    if person[4] == author[2] and person[5] == author[3]:
+                        author[2] = person[1]
+                        author[3] = person[2]
+                    # replace committer if necessary
+                    if person[4] == author[5] and person[5] == author[6]:
+                        author[5] = person[1]
+                        author[6] = person[2]
+
+            csv_writer.write_to_csv(f, authors)
+
+        # (3) Adjust emails lists
+        if emails_list in filenames:
+            f = path.join(filepath, emails_list)
+            log.info("Postprocess %s ...", f)
+            authors = csv_writer.read_from_csv(f)
+
+            for person in disambiguation_data:
+                for author in authors:
+                    # replace author if nessary
+                    if person[4] == author[0] and person[5] == author[1]:
+                        author[0] = person[1]
+                        author[1] = person[2]
+
+            csv_writer.write_to_csv(f, authors)
+
+        # (4) Adjust issues lists (github)
+        if issues_github_list in filenames:
+            f = path.join(filepath, issues_github_list)
+            log.info("Postprocess %s ...", f)
+            authors = csv_writer.read_from_csv(f)
+
+            for person in disambiguation_data:
+                for author in authors:
+                    # replace author if necessary
+                    if person[4] == author[9] and person[5] == author[10]:
+                        author[9] = person[1]
+                        author[10] = person[2]
+                    # replace person in event info 1/2 if necessary
+                    if person[4] == author[12] and person[5] == author[13]:
+                        author[12] = person[1]
+                        author[13] = person[2]
+
+            csv_writer.write_to_csv(f, authors)
+
+        # (5) Adjust issues lists (jira)
+        if issues_jira_list in filenames:
+            f = path.join(filepath, issues_jira_list)
+            log.info("Postprocess %s ...", f)
+            authors = csv_writer.read_from_csv(f)
+
+            for person in disambiguation_data:
+                for author in authors:
+                    # replace author if necessary
+                    if person[4] == author[9] and person[5] == author[10]:
+                        author[9] = person[1]
+                        author[10] = person[2]
+                    # replace person in event info 1/2 if necessary
+                    if person[4] == author[12] and person[5] == author[13]:
+                        author[12] = person[1]
+                        author[13] = person[2]
+
+            csv_writer.write_to_csv(f, authors)
+
+        # (6) Adjust bugs lists (jira)
+        if bugs_jira_list in filenames:
+            f = path.join(filepath, bugs_jira_list)
+            log.info("Postprocess %s ...", f)
+            authors = csv_writer.read_from_csv(f)
+
+            for person in disambiguation_data:
+                for author in authors:
+                    # replace author if necessary
+                    if person[4] == author[9] and person[5] == author[10]:
+                        author[9] = person[1]
+                        author[10] = person[2]
+                    # replace person in event info 1/2 if necessary
+                    if person[4] == author[12] and person[5] == author[13]:
+                        author[12] = person[1]
+                        author[13] = person[2]
+
+            csv.writer.write_to_csv(f, authors)
+
+    log.info("Postprocessing complete!")
+
+
+def get_parser():
+    """
+    Construct parser for the postprocessing process.
+
+    :return: the constructed parser
+    """
+    run_parser = argparse.ArgumentParser(prog='postprocessing', description='postprocessing')
+    run_parser.add_argument('-c', '--config', help="Codeface configuration file",
+                            default='codeface.conf')
+    run_parser.add_argument('-p', '--project', help="Project configuration file",
+                            required=True)
+    run_parser.add_argument('resdir',
+                            help="Directory to store analysis results in")
+
+    return run_parser
+
+
+def run():
+    # get Codeface parser
+    parser = get_parser()
+    args = parser.parse_args(sys.argv[1:])  # Note: The first argument of argv is the name of the command
+
+    # process arguments
+    # - First make all the args absolute
+    __resdir = abspath(args.resdir)
+    __codeface_conf, __project_conf = map(abspath, (args.config, args.project))
+
+    # load configuration
+    __conf = Configuration.load(__codeface_conf, __project_conf)
+
+    run_postprocessing(__conf, __resdir)
+
+
+if __name__ == '__main__':
+    run()

--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -16,7 +16,23 @@
 # Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 # All Rights Reserved.
 """
-This file is able to disambiguate authors after the extraction from the Codeface database was performed. A manually created disambiguation file is used to disambiguate the authors in all the extracted files of a project.
+This file is able to disambiguate authors after the extraction from the Codeface database was performed. A manually
+created disambiguation file is used to disambiguate the authors in all the extracted files of a project.
+
+The manually created disambiguation file 'disambiguation-after-db.list' has to have the following format:
+    - each line combines two person identities which should be mapped to each other
+    - each line consists of six columns (each three for describing id, name, e-mail address)
+    - the entries of each line are taken from the global 'authors.list' file
+    - Example:
+        1234;Claus Hunsen;claus.hunsen@example.org;5678;claushunsen;hunsen.claus@example.net;
+    - the first three columns of a line describe the person identity to keep (e.g., 1234)
+    - the last three columns of a line describe the person identity to replace (e.g., 5678)
+Result: Every occurrence of the second person identity will be replaced by the first person identity, in every .list
+file of the project (authors, commits, emails, issues, etc.)
+
+If more than two person identities should be mapped to each other, several lines are necessary in the disambiguation
+file. E.g., if persons A, B, C should be mapped to A, there has to be a line which replaces B by A (A,B) and a line
+which replaces C by A (A,C).
 """
 
 import argparse
@@ -113,7 +129,7 @@ def run_postprocessing(conf, resdir):
 
             for person in disambiguation_data:
                 for author in authors:
-                    # replace author if nessary
+                    # replace author if necessary
                     if person[4] == author[0] and person[5] == author[1]:
                         author[0] = person[1]
                         author[1] = person[2]

--- a/csv_writer/csv_writer.py
+++ b/csv_writer/csv_writer.py
@@ -14,6 +14,7 @@
 #
 # Copyright 2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 # Copyright 2018 by Anselm Fehnker <fehnker@fim.uni-passau.de>
+# Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 # All Rights Reserved.
 """
 This file provides the needed functions for standardized CSV writing
@@ -52,3 +53,14 @@ def write_to_csv(file_path, lines, append=False):
         for line in lines:
             line_encoded = __encode(line)
             wr.writerow(line_encoded)
+
+def read_from_csv(file_path):
+    """
+    Read lines from a given csv file.
+
+    :param file_path: The path of the file to read from
+
+    :return: A list containing the lines of the read file
+    """
+    content = csv.reader(open(file_path), delimiter=";")
+    return list(content)

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -16,6 +16,7 @@
 # Copyright 2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 # Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
 # Copyright 2018-2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
+# Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 # All Rights Reserved.
 """
 This file is able to extract Jira issue data from xml files.
@@ -125,7 +126,7 @@ def clear_result_files(results_folder):
 
     # construct list of path to output files
     output_files = [os.path.join(results_folder, "issues-jira.list"), os.path.join(results_folder, "bugs-jira.list"),
-                    os.path.join(results_folder, "issue-jira.list"),
+                    os.path.join(results_folder, "issues.list"),
                     os.path.join(results_folder, "issues-jira-gephi-edges.csv"),
                     os.path.join(results_folder, "issues-jira-gephi-nodes.csv")]
 

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -102,10 +102,10 @@ def run():
         issues = insert_user_data(issues, __conf)
         # 5) dump result to disk
         print_to_disk(issues, __resdir)
-        # 6) export for Gephi
-        print_to_disk_gephi(issues, __resdir)
-        # 7) export for jira issue extraction to use them in dev-network-growth
-        print_to_disk_extr(issues, __resdir)
+        # # 6) export for Gephi
+        # print_to_disk_gephi(issues, __resdir)
+        # # 7) export for jira issue extraction to use them in dev-network-growth
+        # print_to_disk_extr(issues, __resdir)
         # 8) dump bug issues to disk
         print_to_disk_bugs(issues, __resdir)
 

--- a/run-author-postprocessing.py
+++ b/run-author-postprocessing.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+# This file is part of codeface-extraction, which is free software: you
+# can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
+# All Rights Reserved.
+
+import author_postprocessing.author_postprocessing as postprocessing
+
+postprocessing.run()


### PR DESCRIPTION
As some author disambiguation done by Codeface is just a heuristic, one might want to manually identify identical authors treated as different authors by Codeface. To unify them, specify a disambiguation list and update all author data in all .list files afterwards.

This fixes se-passau/coronet#178.

