### PR TITLE
Dump usernames-to-user mapping and add bot data processing

### DIFF
--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -13,7 +13,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright 2015-2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
-# Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
+# Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
 # All Rights Reserved.
 """
 This file is able to disambiguate authors after the extraction from the Codeface database was performed. A manually
@@ -104,6 +104,7 @@ def run_postprocessing(conf, resdir, backup_data):
     issues_github_list = "issues-github.list"
     issues_jira_list = "issues-jira.list"
     bugs_jira_list = "bugs-jira.list"
+    bots_list = "bots.list"
 
     # When looking at elements originating from json lists, we need to consider quotation marks around the string
     quot_m = "\""
@@ -120,7 +121,7 @@ def run_postprocessing(conf, resdir, backup_data):
 
     # Check for all files in the result directory of the project whether they need to be adjusted
     for filepath, dirnames, filenames in walk(path.join(resdir, conf["project"], conf["tagging"])):
-        
+
         # (1) Adjust authors lists
         if authors_list in filenames:
             f = path.join(filepath, authors_list)
@@ -230,6 +231,21 @@ def run_postprocessing(conf, resdir, backup_data):
                         bug_event[13] = quot_m + person[2] + quot_m
 
             csv_writer.write_to_csv(f, bug_data)
+
+        # (7) Adjust bots list
+        if bots_list in filenames:
+            f = path.join(filepath, bots_list)
+            log.info("Postprocess %s ...", f)
+            bot_data = csv_writer.read_from_csv(f)
+
+            for person in disambiguation_data:
+                for bot in bot_data:
+                    # replace author if necessary
+                    if person[4] == bot[0] and person[5] == bot[1]:
+                        bot[0] = person[1]
+                        bot[1] = person[2]
+
+            csv_writer.write_to_csv(f, bot_data)
 
     log.info("Postprocessing complete!")
 

--- a/bot_processing/__init__.py
+++ b/bot_processing/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/bot_processing/bot_processing.py
+++ b/bot_processing/bot_processing.py
@@ -1,0 +1,163 @@
+# coding=utf-8
+# This file is part of codeface-extraction, which is free software: you
+# can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
+# All Rights Reserved.
+"""
+This file is able to extract information on bot/human users from csv files.
+"""
+
+import argparse
+import httplib
+import os
+import sys
+import urllib
+
+import operator
+from codeface.cli import log
+from codeface.configuration import Configuration
+
+from csv_writer import csv_writer
+
+def run():
+    # get all needed paths and arguments for the method call.
+    parser = argparse.ArgumentParser(prog='codeface-extraction-bots-github', description='Codeface extraction')
+    parser.add_argument('-c', '--config', help="Codeface configuration file", default='codeface.conf')
+    parser.add_argument('-p', '--project', help="Project configuration file", required=True)
+    parser.add_argument('resdir', help="Directory to store analysis results in")
+
+    # parse arguments
+    args = parser.parse_args(sys.argv[1:])
+    __codeface_conf, __project_conf = map(os.path.abspath, (args.config, args.project))
+
+    # create configuration
+    __conf = Configuration.load(__codeface_conf, __project_conf)
+
+    # get source and results folders
+    __srcdir = os.path.abspath(os.path.join(args.resdir, __conf['repo'] + "_issues"))
+    __resdir = os.path.abspath(os.path.join(args.resdir, __conf['project'], __conf["tagging"]))
+
+    # run processing of bot data:
+    # 1) load bot data
+    bots = load_bot_data(os.path.join(__srcdir, "bots.csv"))
+    # 2) load user data
+    users = load_user_data(os.path.join(__srcdir, "usernames.list"))
+    # 3) update bot data with user data
+    bots = add_user_data(bots, users)
+    # 4) dump result to disk
+    print_to_disk(bots, __resdir)
+
+    log.info("Bot processing complete!")
+
+
+def load_bot_data(bot_file):
+    """Read list of detected bots and human users from disk.
+
+    :param bot_file: the file which contains information about bot and humans users
+    :return: the read bot data
+    """
+
+    log.devinfo("Read bot data from file '{}'...".format(bot_file))
+
+    # check if file exists and exit early if not
+    if not os.path.exists(bot_file):
+        log.error("Bot file '{}' does not exist! Exiting early...".format(bot_file))
+        sys.exit(-1)
+
+    bot_data = csv_writer.read_from_csv(bot_file, delimiter=',')
+
+    # remove first line which contains column headers
+    bot_data = bot_data[1:]
+
+    return bot_data
+
+
+def load_user_data(user_data_file):
+    """
+    Read list of username-to-user mapping from disk.
+
+    :param user_data_file: the file which contains the username-to-user mapping
+    :return: the read user data
+    """
+
+    log.devinfo("Read user data from file '{}'...".format(user_data_file))
+
+    # check if file exists and exit early if not
+    if not os.path.exists(user_data_file):
+        log.error("The file '{}' does not exist! Exiting early...".format(user_data_file))
+        sys.exit(-1)
+
+    user_data = csv_writer.read_from_csv(user_data_file, delimiter=';')
+
+    return user_data
+
+
+def add_user_data(bot_data, user_data):
+    """
+    Add user data to bot data, i.e., replace username by name and e-mail.
+
+    :param bot_data: the list of detected bot/human users
+    :param user_data: the list of usernames to retrieve user data from
+    :return: the updated bot data
+    """
+
+    log.info("Syncing usernames with resolved user data...")
+
+    # create buffer for users (key: username)
+    user_buffer = dict()
+
+    # update user buffer for all users
+    for user in user_data:
+        info = dict()
+        info["name"] = user[1]
+        info["email"] = user[2]
+        user_buffer[user[0]] = info
+
+    # dictionary for all rows of the bot data with reduced number of columns
+    bot_data_reduced = list()
+
+    # update all bots
+    for user in bot_data:
+        bot_reduced = dict()
+        # get user information
+        bot_reduced["user"] = user_buffer[user[0]]
+        bot_reduced["prediction"] = user[-1]
+        bot_data_reduced.append(bot_reduced)
+
+    return bot_data_reduced
+
+
+def print_to_disk(bot_data, results_folder):
+    """
+    Print bot data to file "bots.list" in result folder.
+
+    :param bot_data: the bot data to dump
+    :param results_folder: the folder where to place "bots.list" output file
+    """
+
+    # construct path to output file
+    output_file = os.path.join(results_folder, "bots.list")
+    log.info("Dumping output in file '{}'...".format(output_file))
+
+    # construct lines of output
+    lines = []
+    for user in bot_data:
+        lines.append((
+             user["user"]["name"],
+             user["user"]["email"],
+             user["prediction"]
+        ))
+
+    # write to output file
+    csv_writer.write_to_csv(output_file, lines)

--- a/csv_writer/csv_writer.py
+++ b/csv_writer/csv_writer.py
@@ -14,7 +14,7 @@
 #
 # Copyright 2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 # Copyright 2018 by Anselm Fehnker <fehnker@fim.uni-passau.de>
-# Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
+# Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
 # All Rights Reserved.
 """
 This file provides the needed functions for standardized CSV writing
@@ -54,13 +54,14 @@ def write_to_csv(file_path, lines, append=False):
             line_encoded = __encode(line)
             wr.writerow(line_encoded)
 
-def read_from_csv(file_path):
+def read_from_csv(file_path, delimiter=";"):
     """
     Read lines from a given csv file.
 
     :param file_path: The path of the file to read from
+    :param delimiter: The delimiter of the columns in the csv file to read
 
     :return: A list containing the lines of the read file
     """
-    content = csv.reader(open(file_path), delimiter=";")
+    content = csv.reader(open(file_path), delimiter=delimiter)
     return list(content)

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -53,7 +53,7 @@ known_resolutions = {"unresolved", "fixed", "wontfix", "duplicate", "invalid", "
 datetime_format = "%Y-%m-%d %H:%M:%S"
 
 def run():
-    # get all needed paths and argument for the method call.
+    # get all needed paths and arguments for the method call.
     parser = argparse.ArgumentParser(prog='codeface-extraction-issues-github', description='Codeface extraction')
     parser.add_argument('-c', '--config', help="Codeface configuration file", default='codeface.conf')
     parser.add_argument('-p', '--project', help="Project configuration file", required=True)
@@ -658,7 +658,7 @@ def insert_user_data(issues, conf, srcdir):
 
     :param issues: the issues to retrieve user data from
     :param conf: the project configuration
-    :param srcdir: the directory at which the username-to-user list should be dumped
+    :param srcdir: the directory in which the username-to-user list should be dumped
     :return: the updated issue data
     """
 

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -51,7 +51,7 @@ jira_request_counter = 0
 max_requests = 45000 # 50,000 JIRA requests per 24 hours are allowed
 
 def run():
-    # get all needed paths and argument for the method call.
+    # get all needed paths and arguments for the method call.
     parser = argparse.ArgumentParser(prog="codeface-extraction-issues-jira", description="Codeface extraction")
     parser.add_argument("-c", "--config", help="Codeface configuration file", default="codeface.conf")
     parser.add_argument("-p", "--project", help="Project configuration file", required=True)

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -706,7 +706,7 @@ def print_to_disk(issues, results_folder):
 def print_to_disk_bugs(issues, results_folder):
     """
     Sorts of bug issues and prints them to file "bugs-jira.list" in result folder
-    This method prints in a new format which is consistent to the format of "print_to_disk_new" in "issue_processing.py".
+    This method prints in a format which is consistent to the format of "print_to_disk" in "issue_processing.py".
 
     :param issues: the issues to sort of bugs
     :param results_folder: the folder where to place "bugs-jira.list" output file

--- a/run-bots.py
+++ b/run-bots.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+# This file is part of codeface-extraction, which is free software: you
+# can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
+# All Rights Reserved.
+
+import bot_processing.bot_processing as bots
+
+bots.run()


### PR DESCRIPTION
As we want to use and process GitHub bot data, we need to add a bot processing which maps usernames from the bot data with names and e-mail addresses. In sum, this PR contains the following contributions:

- Make csv delimiter for reading configurable (8773e26)
- Dump username-to-user list during GitHub issue processing, to be able to access username-to-user information during bot processing (9411de4)
- Add bot processing, i.e., read bot data, read user data, update bot data with user data, and dump updated bot data (author name, author email, prediction[bot/human/unknown]) (3ef2d11)
- Add bot data to author postprocessing (032f026)

This fixes #37.