### PR TITLE
Fix user-handling in JIRA issue processing

### DIFF
--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -602,24 +602,37 @@ def insert_user_data(issues, conf):
         # check database for issue author
         issue["author"] = get_id_and_update_user(issue["author"])
 
-        # check database for event authors
+        # check database for comment authors
         for comment in issue["comments"]:
             comment["author"] = get_id_and_update_user(comment["author"])
-            # # check database for the reference-target user if needed
-            # if event["ref_target"] != "":
-            #     event["ref_target"] = get_id_and_update_user(event["ref_target"])
+
+        # check database for event authors in the history
+        for event in issue["history"]:
+            event["author"] = get_id_and_update_user(event["author"])
+
+            # check database for target user if needed
+            if event["event"] == "assigned":
+                assigned_user = get_id_and_update_user(create_user(event["event_info_1"], "", event["event_info_2"]))
+                event["event_info_1"] = assigned_user
 
     # get all users after database updates having been performed
     for issue in issues:
         # get issue author
         issue["author"] = get_user_from_id(issue["author"])
 
-        # get event authors
+        # get comment authors
         for comment in issue["comments"]:
             comment["author"] = get_user_from_id(comment["author"])
-            # # get the reference-target user if needed
-            # if event["ref_target"] != "":
-            #     event["ref_target"] = get_user_from_id(event["ref_target"])
+
+        # get event authors for non-comment events
+        for event in issue["history"]:
+            event["author"] = get_user_from_id(event["author"])
+
+            # get target user if needed
+            if event["event"] == "assigned":
+                assigned_user = get_user_from_id(event["event_info_1"])
+                event["event_info_1"] = assigned_user["name"]
+                event["event_info_2"] = assigned_user["email"]
 
     log.debug("number of issues after insert_user_data: '{}'".format(len(issues)))
     return issues

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -438,7 +438,7 @@ def load_issue_via_api(issues, persons, url):
                     history["event_info_1"] = new_state
                     history["event_info_2"] = old_state
                     if hasattr(change, "author"):
-                        user = create_user(change.author.name, change.author.name, "")
+                        user = create_user(change.author.displayName, change.author.name, "")
                     else:
                         log.warn("No author for history: " + str(change.id) + " created at " + str(change.created))
                         user = create_user("","","")
@@ -458,7 +458,7 @@ def load_issue_via_api(issues, persons, url):
                     history["event_info_1"] = new_resolution
                     history["event_info_2"] = old_resolution
                     if hasattr(change, "author"):
-                        user = create_user(change.author.name, change.author.name, "")
+                        user = create_user(change.author.displayName, change.author.name, "")
                     else:
                         log.warn("No author for history: " + str(change.id) + " created at " + str(change.created))
                         user = create_user("","","")
@@ -471,9 +471,9 @@ def load_issue_via_api(issues, persons, url):
                 elif item.field == "assignee":
                     history = dict()
                     history["event"] = "assigned"
-                    user = create_user(change.author.name, change.author.name, "")
+                    user = create_user(change.author.displayName, change.author.name, "")
                     history["author"] = merge_user_with_user_from_csv(user, persons)
-                    assignee = create_user(item.toString, item.toString, "")
+                    assignee = create_user(item.toString, item.to, "")
                     assigned_user = merge_user_with_user_from_csv(assignee, persons)
                     history["event_info_1"] = assigned_user["name"]
                     history["event_info_2"] = assigned_user["email"]
@@ -485,7 +485,7 @@ def load_issue_via_api(issues, persons, url):
                     if item.toString is not None:
                         history = dict()
                         history["event"] = "add_link"
-                        user = create_user(change.author.name, change.author.name, "")
+                        user = create_user(change.author.displayName, change.author.name, "")
                         history["author"] = merge_user_with_user_from_csv(user, persons)
                         # api returns a text. The issueId is at the end of the text and gets extracted
                         history["event_info_1"] = item.toString.split()[-1]
@@ -497,7 +497,7 @@ def load_issue_via_api(issues, persons, url):
                     if item.fromString is not None:
                         history = dict()
                         history["event"] = "remove_link"
-                        user = create_user(change.author.name, change.author.name, "")
+                        user = create_user(change.author.displayName, change.author.name, "")
                         history["author"] = merge_user_with_user_from_csv(user, persons)
                         # api returns a text. Th issue id is at the end of the text and gets extracted
                         history["event_info_1"] = item.fromString.split()[-1]

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -102,7 +102,13 @@ def run():
         if not args.skip_history:
             load_issue_via_api(issues, persons, __conf["issueTrackerURL"])
         # 4) update user data with Codeface database
-        # mabye not nessecary
+        #    ATTENTION: As the database update is performed for every iteration in this for loop, but the current issue
+        #    data is appended to the results file immediately, the database updates from the later iterations are not
+        #    respected in the previously dumped issues from the previous iterations. However, as we don't get email
+        #    data from JIRA, this is currently not a problem, as no names will change in the database if we don't
+        #    provide emails. If JIRA will provide email data in the future, this implementation needs to be adjusted
+        #    in such a way that users in issue data of all iterations are updated in the end and dumped afterwards,
+        #    instead of dumping the intermediate issue data immediately.
         issues = insert_user_data(issues, __conf)
         # 5) dump result to disk
         print_to_disk(issues, __resdir)
@@ -509,7 +515,7 @@ def load_issue_via_api(issues, persons, url):
 
 def insert_user_data(issues, conf):
     """
-    Insert user data into database ad update issue data.
+    Insert user data into database and update issue data.
 
     :param issues: the issues to retrieve user data from
     :param conf: the project configuration


### PR DESCRIPTION
Unfortunately, it turned out that our JIRA issue processing contains some bugs and inconsistencies regarding user handling and disambiguation using the Codeface database:

- Usernames occurring in JIRA issue data are merged with the JIRA user data (containing name and e-mail address). However, up to now, we check only if the username is contained in the user data. We improve this procedure and additionally check if the name is contained in the user data if the username is not contained. To achieve this, we need a second person dictionary, where the key is the name. This way, we can merge user data if we have the name but not the username. (bc2abeb)
- When collecting information from JIRA issue history data, we only extracted the username of an author though the name (called "displayName" is also available). As stated above, in cases where the username is not contained in the person data, we now use the name for merging. Hence, also extract the name from the history data (holds for authors of events in the history and also for assigned users). (1d7a0d6)
- Fix a bug regarding the user updates with the Codeface database: Previously, only issue authors and comment authors have been updated with the Codeface database, but not authors of events in the history nor assigned users. Now, we also update them correctly. (3925163)
- Add a comment to be aware of the following potential problem: As we dump the JIRA issue data to file step by step for each parsed xml file, the users may be not update to date with the database updates any more, as later updates of a user are not respected in earlier dumped issues. However, this is not a problem for now, as we don't get e-mail addresses from JIRA, so database updates are not necessary and therefore, names cannot change. However, if there would be e-mail addresses, the behavior needs to be fixed such that users are updated after parsing all xml files and dumping issues is only performed at the end. (6daf45d)