### PR TITLE
Add more bots in bots processing & Handle GitHub author properly

### DIFF
--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -78,23 +78,40 @@ def perform_data_backup(results_path, results_path_backup):
                     copy(current_file, backup_file)
 
 
-def fix_github_browser_commits(data_path, issues_github_list, commits_list, authors_list):
+def fix_github_browser_commits(data_path, issues_github_list, commits_list, authors_list, emails_list):
     """
     Replace the author "GitHub <noreply@github.com>" in both commit and GitHub issue data by the correct author.
     The author "GitHub <noreply@github.com>" is automatically inserted as the committer of a commit that is made when
     editing a file via the web frontend of GitHub. Hence, replace the committer of such commits with the commit's
     author, as author and committer are the same person in such a situation. This also holds for the "commit_added"
     event in GitHub issue data: As this usually uses the committer of a commit as its author, also use the commit's
-    author as the author of the "commit_added" event.
+    author as the author of the "commit_added" event. In addition, remove the author "GitHub <noreply@github.com>"
+    also from the author data and remove e-mails that have been sent by this author.
 
     :param data_path: the path to the project data that is to be fixed
     :param issues_github_list: file name of the github issue data
     :param commits_list: file name of the corresponding commit data
     :param authors_list: file name of the corresponding author data
+    :param emails_list: file name of the corresponding email data
     """
     github_user = "GitHub"
     github_email = "noreply@github.com"
     commit_added_event = "commit_added"
+
+    """
+    Helper function to check whether a (name, e-mail) pair belongs to the author "GitHub <noreply@github.com>".
+    There are two options in Codeface how this can happen:
+    (1) Username is "GitHub" and e-mail address is "noreply@github.com"
+    (2) Username is "GitHub" and e-mail address has been replaced by Codeface, resulting in "GitHub.noreply@github.com"
+
+    :param name: the name of the author to be checked
+    :param email: the email address of the author to be checked
+    :return: whether the given (name, email) pair belongs to the "GitHub <noreply@github.com>" author
+
+    """
+    def is_github_noreply_author(name, email):
+        return (name == github_user and (email == github_email or email == (github_user + "." + github_email)))
+
 
     # Check for all files in the result directory of the project whether they need to be adjusted
     for filepath, dirnames, filenames in walk(data_path):
@@ -109,11 +126,28 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
 
             for author in author_data:
                 # keep author entry only if it should not be removed
-                if not (author[1] == github_user and author[2] == github_email):
+                if not is_github_noreply_author(author[1], author[2]):
                     author_data_new.append(author)
             csv_writer.write_to_csv(f, author_data_new)
 
-        # (2) Replace the committer 'GitHub <noreply@github.com>' in all commit.list files
+        # (2) Remove e-mails from author 'GitHub <noreply@github.com>' from all emails.list files
+        if emails_list in filenames:
+            f = path.join(filepath, emails_list)
+            log.info("Remove emails from author %s <%s> in %s ...", github_user, github_email, f)
+            email_data = csv_writer.read_from_csv(f)
+
+            email_data_new = []
+
+            for email in email_data:
+                # keep author entry only if it should not be removed
+                if not is_github_noreply_author(email[0], email[1]):
+                    email_data_new.append(email)
+                else:
+                    log.warn("Remove email %s as it was sent by %s <%s>.", email[2], email[0], email[1])
+            csv_writer.write_to_csv(f, email_data_new)
+
+
+        # (3) Replace the committer 'GitHub <noreply@github.com>' in all commit.list files
         if commits_list in filenames:
             f = path.join(filepath, commits_list)
             log.info("Replace author %s <%s> in %s ...", github_user, github_email, f)
@@ -122,13 +156,13 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
             for commit in commit_data:
                 # replace committer 'GitHub <noreply@github.com>' by the commit's author
                 # (as author and committer are identical when using GitHub's browser interface)
-                if commit[5] == github_user and commit[6] == github_email:
+                if is_github_noreply_author(commit[5], commit[6]):
                     commit[5] = commit[2]
                     commit[6] = commit[3]
 
             csv_writer.write_to_csv(f, commit_data)
 
-        # (3) Replace author 'GitHub <noreply@github.com>' in all "commit_added" events in the GitHub issue data
+        # (4) Replace author 'GitHub <noreply@github.com>' in all "commit_added" events in the GitHub issue data
         if issues_github_list in filenames:
             f = path.join(filepath, issues_github_list)
             log.info("Replace author %s <%s> in %s ...", github_user, github_email, f)
@@ -143,7 +177,7 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
 
             for event in issue_data:
                 # replace author if necessary
-                if event[9] == github_user and event[10] == github_email and event[8] == commit_added_event:
+                if is_github_noreply_author(event[9], event[10]) and event[8] == commit_added_event:
                     # extract commit hash from event info 1
                     commit_hash = event[12]
 
@@ -188,8 +222,6 @@ def run_postprocessing(conf, resdir, backup_data):
         perform_data_backup(results_path, results_path_backup)
         log.info("%s: Backup of current data complete!" % conf["project"])
 
-    log.info("%s: Postprocess authors after manual disambiguation" % conf["project"])
-
     authors_list = "authors.list"
     commits_list = "commits.list"
     emails_list = "emails.list"
@@ -204,8 +236,8 @@ def run_postprocessing(conf, resdir, backup_data):
     data_path = path.join(resdir, conf["project"], conf["tagging"])
 
     # Correctly replace author 'GitHub <noreply@github.com>' in the commit data and in "commit_added" events of the
-    # GitHub issue data
-    fix_github_browser_commits(data_path, issues_github_list, commits_list, authors_list)
+    # GitHub issue data and remove this author in the author data and e-mail data
+    fix_github_browser_commits(data_path, issues_github_list, commits_list, authors_list, emails_list)
 
     log.info("%s: Postprocess authors after manual disambiguation" % conf["project"])
     disambiguation_list = path.join(data_path, "disambiguation-after-db.list")

--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -18,7 +18,7 @@
 """
 This file is able to disambiguate authors after the extraction from the Codeface database was performed. A manually
 created disambiguation file is used to disambiguate the authors in all the extracted files of a project. In addition,
-the author "GitHub <noreply@github.com" is removed from all the data and is either replaced by the actual author or,
+the author "GitHub <noreply@github.com>" is removed from all the data and is either replaced by the actual author or,
 if this is not possible, the corresponding event is removed from the data.
 
 The manually created disambiguation file 'disambiguation-after-db.list' has to have the following format:
@@ -107,7 +107,6 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
     :param name: the name of the author to be checked
     :param email: the email address of the author to be checked
     :return: whether the given (name, email) pair belongs to the "GitHub <noreply@github.com>" author
-
     """
     def is_github_noreply_author(name, email):
         return (name == github_user and (email == github_email or email == (github_user + "." + github_email)))
@@ -189,7 +188,7 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
                     else:
                         # the added commit is not part of the commit data. In most cases, this is due to merge commits
                         # appearing in another pull request, as Codeface does not keep track of merge commits. As we
-                        # ignore merge commits in the commit data, we consistenly ignore them also if they are added
+                        # ignore merge commits in the commit data, we consistently ignore them also if they are added
                         # to a pull request. Hence, the corresponding "commit_added" event will be removed now (i.e.,
                         # not added to the new issue data any more).
                         log.warn("Commit %s is added in the GitHub issue data, but not part of the commit data. " +

--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -17,7 +17,9 @@
 # All Rights Reserved.
 """
 This file is able to disambiguate authors after the extraction from the Codeface database was performed. A manually
-created disambiguation file is used to disambiguate the authors in all the extracted files of a project.
+created disambiguation file is used to disambiguate the authors in all the extracted files of a project. In addition,
+the author "GitHub <noreply@github.com" is removed from all the data and is either replaced by the actual author or,
+if this is not possible, the corresponding event is removed from the data.
 
 The manually created disambiguation file 'disambiguation-after-db.list' has to have the following format:
     - each line combines two person identities which should be mapped to each other
@@ -76,6 +78,96 @@ def perform_data_backup(results_path, results_path_backup):
                     copy(current_file, backup_file)
 
 
+def fix_github_browser_commits(data_path, issues_github_list, commits_list, authors_list):
+    """
+    Replace the author "GitHub <noreply@github.com>" in both commit and GitHub issue data by the correct author.
+    The author "GitHub <noreply@github.com>" is automatically inserted as the committer of a commit that is made when
+    editing a file via the web frontend of GitHub. Hence, replace the committer of such commits with the commit's
+    author, as author and committer are the same person in such a situation. This also holds for the "commit_added"
+    event in GitHub issue data: As this usually uses the committer of a commit as its author, also use the commit's
+    author as the author of the "commit_added" event.
+
+    :param data_path: the path to the project data that is to be fixed
+    :param issues_github_list: file name of the github issue data
+    :param commits_list: file name of the corresponding commit data
+    :param authors_list: file name of the corresponding author data
+    """
+    github_user = "GitHub"
+    github_email = "noreply@github.com"
+    commit_added_event = "commit_added"
+
+    # Check for all files in the result directory of the project whether they need to be adjusted
+    for filepath, dirnames, filenames in walk(data_path):
+
+        # (1) Remove author 'GitHub <noreply@github.com>' from authors list
+        if authors_list in filenames:
+            f = path.join(filepath, authors_list)
+            log.info("Remove author %s <%s> in %s ...", github_user, github_email, f)
+            author_data = csv_writer.read_from_csv(f)
+
+            author_data_new = []
+
+            for author in author_data:
+                # keep author entry only if it should not be removed
+                if not (author[1] == github_user and author[2] == github_email):
+                    author_data_new.append(author)
+            csv_writer.write_to_csv(f, author_data_new)
+
+        # (2) Replace the committer 'GitHub <noreply@github.com>' in all commit.list files
+        if commits_list in filenames:
+            f = path.join(filepath, commits_list)
+            log.info("Replace author %s <%s> in %s ...", github_user, github_email, f)
+            commit_data = csv_writer.read_from_csv(f)
+
+            for commit in commit_data:
+                # replace committer 'GitHub <noreply@github.com>' by the commit's author
+                # (as author and committer are identical when using GitHub's browser interface)
+                if commit[5] == github_user and commit[6] == github_email:
+                    commit[5] = commit[2]
+                    commit[6] = commit[3]
+
+            csv_writer.write_to_csv(f, commit_data)
+
+        # (3) Replace author 'GitHub <noreply@github.com>' in all "commit_added" events in the GitHub issue data
+        if issues_github_list in filenames:
+            f = path.join(filepath, issues_github_list)
+            log.info("Replace author %s <%s> in %s ...", github_user, github_email, f)
+            issue_data = csv_writer.read_from_csv(f)
+
+            # read commit data
+            commit_data_file = path.join(data_path, commits_list)
+            commit_data = csv_writer.read_from_csv(commit_data_file)
+            commit_hash_to_author = {commit[7]: commit[2:4] for commit in commit_data}
+
+            issue_data_new = []
+
+            for event in issue_data:
+                # replace author if necessary
+                if event[9] == github_user and event[10] == github_email and event[8] == commit_added_event:
+                    # extract commit hash from event info 1
+                    commit_hash = event[12]
+
+                    # extract commit author from commit data, if available
+                    if commit_hash in commit_hash_to_author:
+                        event[9] = commit_hash_to_author[commit_hash][0]
+                        event[10] = commit_hash_to_author[commit_hash][1]
+                        issue_data_new.append(event)
+                    else:
+                        # the added commit is not part of the commit data. In most cases, this is due to merge commits
+                        # appearing in another pull request, as Codeface does not keep track of merge commits. As we
+                        # ignore merge commits in the commit data, we consistenly ignore them also if they are added
+                        # to a pull request. Hence, the corresponding "commit_added" event will be removed now (i.e.,
+                        # not added to the new issue data any more).
+                        log.warn("Commit %s is added in the GitHub issue data, but not part of the commit data. " +
+                                 "Remove the corresponding 'commit_added' event from the issue data...", commit_hash)
+                else:
+                    issue_data_new.append(event)
+
+            csv_writer.write_to_csv(f, issue_data_new)
+
+    log.info("Replacing GitHub user: Done.")
+
+
 def run_postprocessing(conf, resdir, backup_data):
     """
     Runs the postprocessing for the given parameters, that is, read the disambiguation file of the project
@@ -109,7 +201,14 @@ def run_postprocessing(conf, resdir, backup_data):
     # When looking at elements originating from json lists, we need to consider quotation marks around the string
     quot_m = "\""
 
-    disambiguation_list = path.join(resdir, conf["project"], conf["tagging"], "disambiguation-after-db.list")
+    data_path = path.join(resdir, conf["project"], conf["tagging"])
+
+    # Correctly replace author 'GitHub <noreply@github.com>' in the commit data and in "commit_added" events of the
+    # GitHub issue data
+    fix_github_browser_commits(data_path, issues_github_list, commits_list, authors_list)
+
+    log.info("%s: Postprocess authors after manual disambiguation" % conf["project"])
+    disambiguation_list = path.join(data_path, "disambiguation-after-db.list")
 
     # Check if a disambiguation list exists - if not, just stop
     if path.exists(disambiguation_list):
@@ -120,7 +219,7 @@ def run_postprocessing(conf, resdir, backup_data):
         return
 
     # Check for all files in the result directory of the project whether they need to be adjusted
-    for filepath, dirnames, filenames in walk(path.join(resdir, conf["project"], conf["tagging"])):
+    for filepath, dirnames, filenames in walk(data_path):
 
         # (1) Adjust authors lists
         if authors_list in filenames:

--- a/bot_processing/bot_processing.py
+++ b/bot_processing/bot_processing.py
@@ -48,23 +48,30 @@ def run():
     __srcdir = os.path.abspath(os.path.join(args.resdir, __conf['repo'] + "_issues"))
     __resdir = os.path.abspath(os.path.join(args.resdir, __conf['project'], __conf["tagging"]))
 
+    # get folder that contains known bots file
+    # (the known bots file is the file in which known bots have been added manually and project independent)
+    __confdir = os.path.join(args.resdir, os.path.dirname(args.config))
+    __known_bots_file = os.path.abspath(os.path.join(__confdir, "known_github_bots.list"))
+
     # run processing of bot data:
     # 1) load bot data
-    bots = load_bot_data(os.path.join(__srcdir, "bots.csv"))
+    bots = load_bot_data(os.path.join(__srcdir, "bots.csv"), header = True)
     # 2) load user data
     users = load_user_data(os.path.join(__srcdir, "usernames.list"))
-    # 3) update bot data with user data
-    bots = add_user_data(bots, users)
+    # 3) update bot data with user data and additionally add known bots if they occur in the project
+    bots = add_user_data(bots, users, __known_bots_file)
     # 4) dump result to disk
     print_to_disk(bots, __resdir)
 
     log.info("Bot processing complete!")
 
 
-def load_bot_data(bot_file):
-    """Read list of detected bots and human users from disk.
+def load_bot_data(bot_file, header = True):
+    """
+    Read list of detected bots and human users from disk.
 
     :param bot_file: the file which contains information about bot and humans users
+    :param header: whether the file to be read contains a header or not (default: True)
     :return: the read bot data
     """
 
@@ -77,8 +84,9 @@ def load_bot_data(bot_file):
 
     bot_data = csv_writer.read_from_csv(bot_file, delimiter=',')
 
-    # remove first line which contains column headers
-    bot_data = bot_data[1:]
+    if header:
+        # remove first line which contains column headers
+        bot_data = bot_data[1:]
 
     return bot_data
 
@@ -103,9 +111,57 @@ def load_user_data(user_data_file):
     return user_data
 
 
-def add_user_data(bot_data, user_data):
+def check_with_known_bot_list(known_bots_file, bot_data, user_data, bot_data_reduced):
+    """
+    Check whether there are known bots occurring in the project. If so, add them to the bots list
+    or update the bots list accordingly.
+
+    :param known_bots_file: the file path to the list of known bot data
+    :param bot_data: the bot data originating from the bot prediction
+    :param user_data: a dictionary from the issue data which maps GitHub usernames to authors
+    :param bot_data_reduced: the bot data after mapping GitHub user names to authors
+    :return: the bot data as provided in param 'bot_data_reduced' but possibly enrichted with
+             additional bots (if occurring) or updated bots
+    """
+
+    # Read the list of known bots
+    known_bots = load_bot_data(known_bots_file, header = False)
+
+    # Get the GitHub usernames of the bots predicted to be a bot
+    predicted_bots = [bot[0] if len(bot) > 0 else "" for bot in bot_data]
+
+    for bot in known_bots:
+
+        # (1) check if a known bot occurs in the GitHub issue data but has not been predicted
+        if bot[0] not in predicted_bots and bot[0] in user_data:
+
+            # add the known bot as a bot to the bots list
+            additional_bot = dict()
+            additional_bot["user"] = user_data[bot[0]]
+            additional_bot["prediction"] = "Bot"
+            bot_data_reduced.append(additional_bot)
+            log.info("Add known bot '{}' to bot data.".format(additional_bot["user"]))
+
+        # (2) handle known bots that are already present in the bots list
+        elif bot[0] in predicted_bots and bot[0] in user_data:
+
+            # make sure that this bot has also been predicited to be bot
+            for predicted_bot in bot_data_reduced:
+                if predicted_bot["user"] == user_data[bot[0]]:
+                    predicted_bot["prediction"] = "Bot"
+                    log.info("Mark user '{}' as bot in the bot data.".format(user_data[bot[0]]))
+                    break
+
+    # return the updated bot data
+    return bot_data_reduced
+
+
+def add_user_data(bot_data, user_data, known_bots_file):
     """
     Add user data to bot data, i.e., replace username by name and e-mail.
+    In addition, check in the global bots list whether there are authors in the projects which are
+    globally known to be bots. If so, add them to the bots list and update the resulting bots list
+    accordingly.
 
     :param bot_data: the list of detected bot/human users
     :param user_data: the list of usernames to retrieve user data from
@@ -142,6 +198,9 @@ def add_user_data(bot_data, user_data):
             bot_data_reduced.append(bot_reduced)
         else:
             log.warn("User '{}' in bot data does not occur in GitHub user data. Remove user...".format(user[0]))
+
+    # check whether known GitHub bots occur in the GitHub issue data and, if so, update the bot data accordingly
+    bot_data_reduced = check_with_known_bot_list(known_bots_file, bot_data, user_buffer, bot_data_reduced)
 
     return bot_data_reduced
 

--- a/bot_processing/bot_processing.py
+++ b/bot_processing/bot_processing.py
@@ -120,7 +120,7 @@ def check_with_known_bot_list(known_bots_file, bot_data, user_data, bot_data_red
     :param bot_data: the bot data originating from the bot prediction
     :param user_data: a dictionary from the issue data which maps GitHub usernames to authors
     :param bot_data_reduced: the bot data after mapping GitHub user names to authors
-    :return: the bot data as provided in param 'bot_data_reduced' but possibly enrichted with
+    :return: the bot data as provided in param 'bot_data_reduced' but possibly enriched with
              additional bots (if occurring) or updated bots
     """
 


### PR DESCRIPTION
In this PR, we fix two problems:

(1) There might be known GitHub bots that do not post comments or are not automatically identified as bots. Hence, we enable adding bots from a project-independent list of known bots. (71617a8)

(2) The author 'GitHub <noreply@github.com>' can appear in the data, mostly due to edits via the Web interface of GitHub. However, this distorts the data as the actual user is obfuscated. To avoid problems, we need to get rid of this author. This is fixed in the commit data, GitHub issue data, and author data. (8064b0d)
As this author can also occur in the mail data, we also need to handle this author properly when processing the mail data. That is, we remove such e-mails. In addition, we also perform the same steps if the e-mail address is 'GitHub.noreply@github.com'. (6cac280)