### PR TITLE
Fix overwriting usernames.list by changing the directory for this file

### DIFF
--- a/bot_processing/bot_processing.py
+++ b/bot_processing/bot_processing.py
@@ -57,7 +57,7 @@ def run():
     # 1) load bot data
     bots = load_bot_data(os.path.join(__srcdir, "bots.csv"), header = True)
     # 2) load user data
-    users = load_user_data(os.path.join(__srcdir, "usernames.list"))
+    users = load_user_data(os.path.join(__resdir, "usernames.list"))
     # 3) update bot data with user data and additionally add known bots if they occur in the project
     bots = add_user_data(bots, users, __known_bots_file)
     # 4) dump result to disk

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -79,8 +79,8 @@ def run():
     issues = merge_issue_events(issues)
     # 4) re-format the eventsList of the issues
     issues = reformat_events(issues)
-    # 5) update user data with Codeface database
-    issues = insert_user_data(issues, __conf, __srcdir)
+    # 5) update user data with Codeface database and dump username-to-name/e-mail list
+    issues = insert_user_data(issues, __conf, __resdir)
     # 6) dump result to disk
     print_to_disk(issues, __resdir)
 
@@ -651,14 +651,14 @@ def reformat_events(issue_data):
     return issue_data
 
 
-def insert_user_data(issues, conf, srcdir):
+def insert_user_data(issues, conf, resdir):
     """
     Insert user data into database and update issue data.
     In addition, dump username-to-user list to file.
 
     :param issues: the issues to retrieve user data from
     :param conf: the project configuration
-    :param srcdir: the directory in which the username-to-user list should be dumped
+    :param resdir: the directory in which the username-to-user-list should be dumped
     :return: the updated issue data
     """
 
@@ -775,7 +775,7 @@ def insert_user_data(issues, conf, srcdir):
         ))
 
     log.info("Dump username list to file...")
-    username_dump = os.path.join(srcdir, "usernames.list")
+    username_dump = os.path.join(resdir, "usernames.list")
     csv_writer.write_to_csv(username_dump, sorted(set(lines), key=lambda line: line[0]))
 
     return issues


### PR DESCRIPTION
When performing the GitHub issue processing, we write a file 'usernames.list'
which contains a mapping from usernames to name/e-mail pairs, needed for bot
processing. However, in the previous implementation, we stored this file in
the '_issues' directory, independent of the tagging ('proximity' or 'feature'),
ending up in feature and proximity analysis overwriting the file of each other.

As feature and proximity analsis can lead to different e-mail addresses
(especially in randomly generated e-mail addresses if no e-mail address is
available), we need to store them separatly for feature and proximity analysis,
otherwise bot processing will fail.

With this commit, we change the directory where the 'usernames.list' list file is
stored from '_issues' to the '_proximity/proximity' and '_feature/feature'
directory respectively.

This is a follow-up PR for PR #38.