### PR TITLE
Remove duplicates from bot data

### DIFF
--- a/bot_processing/bot_processing.py
+++ b/bot_processing/bot_processing.py
@@ -12,7 +12,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# Copyright 2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
+# Copyright 2021-2022 by Thomas Bock <bockthom@cs.uni-saarland.de>
 # All Rights Reserved.
 """
 This file is able to extract information on bot/human users from csv files.
@@ -220,11 +220,12 @@ def print_to_disk(bot_data, results_folder):
     # construct lines of output
     lines = []
     for user in bot_data:
-        lines.append((
-             user["user"]["name"],
-             user["user"]["email"],
-             user["prediction"]
-        ))
+        entry = (user["user"]["name"],
+                 user["user"]["email"],
+                 user["prediction"]
+                )
+        if not entry in lines:
+            lines.append(entry)
 
     # write to output file
     csv_writer.write_to_csv(output_file, lines)


### PR DESCRIPTION
It can happen that authors are joined multiple times to the "usernames.list".
Therefore, when processing the bot data, we need to remove duplicates.

Again, this can also happen when post-processing the bot data: When replace the
(author.name, e-mail) pair in the bot data according to the disambigation list,
a (author.name, e-mail) pair might be introduced that has already been
introduced before. So, here, we also need to remove duplicates (and make sure
that we keep the correct entry (e.g., where the last column is "Bot" and not
"unknown", if we have multiple entries with different classifications).
We keep "Bot" if, at least, one of the classifications is "Bot". Otherwise, we
keep "Human" if, at least, one of the classifications is "Human".