### PR TITLE
Do not try to fix encoding of non-existent text

### DIFF
--- a/codeface_extraction/extractions.py
+++ b/codeface_extraction/extractions.py
@@ -729,6 +729,10 @@ def fix_characters_in_string(text):
     :return: unicode string
     """
 
+    # do not even try to fix the encoding etc. if there is no text given
+    if text is None:
+        return None
+
     # deal with encoding
     new_text = fix_encoding(text)
 


### PR DESCRIPTION
When the commit message of a commit is missing, then `fix_characters_in_string` is called with parameter `None`. However, `None` is not allowed in the function `fix_encoding`. Therefore, we need to perform a `None` check before `fix_encoding` is called. If the text input is `None`, we now just return `None` without any other fixes.

This change is caused by the new handling of missing commit messages in codeface, as now there can be commits without commit message in the codeface database. For more information, see also:
https://github.com/se-sic/codeface/commit/51073b2d86448b504689f0cb43d99b2007911d03