### PR TITLE
Author reconstruction for 'GitHub' user, handling of new GitHub events, handling of GitHub Copilot and other agents

### DIFF
--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -178,7 +178,7 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
             commit_data_file = path.join(data_path, commits_list)
             commit_data = csv_writer.read_from_csv(commit_data_file)
             commit_hash_to_author = {commit[7]: commit[2:4] for commit in commit_data}
-
+            author_name_to_data = {author[1]: author[1:3] for author in author_data_new}
             issue_data_new = []
 
             for event in issue_data:
@@ -186,11 +186,15 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
                 if is_github_noreply_author(event[9], event[10]) and event[8] == commit_added_event:
                     # extract commit hash from event info 1
                     commit_hash = event[12]
-
+                    name = event[13][1:-1]
                     # extract commit author from commit data, if available
                     if commit_hash in commit_hash_to_author:
                         event[9] = commit_hash_to_author[commit_hash][0]
                         event[10] = commit_hash_to_author[commit_hash][1]
+                        issue_data_new.append(event)
+                    elif name in author_name_to_data:
+                        event[9] = author_name_to_data[name][0]
+                        event[10] = author_name_to_data[name][1]
                         issue_data_new.append(event)
                     else:
                         # the added commit is not part of the commit data. In most cases, this is due to merge commits

--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -99,7 +99,7 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
     "GitHub <noreply@github.com>" are removed. Also "mentioned" or "subscribed" events in the GitHub issue data which
     reference the author "GitHub <noreply@github.com>" are removed from the GitHub issue data. In addition, remove the
     author "GitHub <noreply@github.com>" also from the author data and bot data and remove e-mails that have been sent
-    by this author.
+    by this author. This method also unifies all known copilot users into a single user if desired.
 
     :param data_path: the path to the project data that is to be fixed
     :param issues_github_list: file name of the github issue data
@@ -107,6 +107,7 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
     :param authors_list: file name of the corresponding author data
     :param emails_list: file name of the corresponding email data
     :param bots_list: file name of the corresponding bot data
+    :param unify_copilot_users: whether to unify known copilot users into a single user
     """
     github_user = "GitHub"
     github_email = "noreply@github.com"

--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -52,9 +52,9 @@ from csv_writer import csv_writer
 
 from github_user_utils import known_copilot_users, copilot_unified_name, copilot_unified_email, \
                               is_github_noreply_author, github_user, github_email, \
-                              commit_added_event, mentioned_event, subscribed_event
+                              commit_added_event, mentioned_event, subscribed_event, generate_botname_variants
 
-
+known_copilot_users_extended = generate_botname_variants(known_copilot_users)
 ##
 # RUN POSTPROCESSING
 ##
@@ -122,7 +122,7 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
                 # keep author entry only if it should not be removed
                 if not is_github_noreply_author(author[1], author[2]):
                     # unify copilot author if desired
-                    if unify_copilot_users and author[1] in known_copilot_users:
+                    if unify_copilot_users and author[1] in known_copilot_users_extended:
                         if not copilot_user_added:
                             author[1] = copilot_unified_name
                             author[2] = copilot_unified_email
@@ -146,7 +146,7 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
                 # keep author entry only if it should not be removed
                 if not is_github_noreply_author(email[0], email[1]):
                     # unify copilot users if desired
-                    if unify_copilot_users and email[0] in known_copilot_users:
+                    if unify_copilot_users and email[0] in known_copilot_users_extended:
                         email[0] = copilot_unified_name
                         email[1] = copilot_unified_email
                     email_data_new.append(email)
@@ -170,7 +170,7 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
                     commit[5] = commit[2]
                     commit[6] = commit[3]
                 # unify copilot author if desired
-                if unify_copilot_users and commit[5] in known_copilot_users:
+                if unify_copilot_users and commit[5] in known_copilot_users_extended:
                     commit[5] = copilot_unified_name
                     commit[6] = copilot_unified_email
 
@@ -194,13 +194,13 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
 
             for event in issue_data:
                 # unify events to use a single copilot user for all events triggered by a known copilot user
-                if unify_copilot_users and event[9] in known_copilot_users:
+                if unify_copilot_users and event[9] in known_copilot_users_extended:
                     event[9] = copilot_unified_name
                     event[10] = copilot_unified_email
-                    if event[8] == commit_added_event and event[13][-1:1] in known_copilot_users:
+                    if event[8] == commit_added_event and event[13][-1:1] in known_copilot_users_extended:
                         # for commit added events, also unify the referenced author in event info 2 if it is a known copilot user
                         event[13] = '"' + copilot_unified_name + '"'
-                    elif event[8] in (mentioned_event, subscribed_event) and event[12][-1:1] in known_copilot_users:
+                    elif event[8] in (mentioned_event, subscribed_event) and event[12][-1:1] in known_copilot_users_extended:
                         # for mentioned/subscribed events, also unify the referenced user in event info 1 and 2 if it is a known copilot user
                         event[12] = '"' + copilot_unified_name + '"'
                         event[13] = '"' + copilot_unified_email + '"'

--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -247,6 +247,9 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
         if bots_list in filenames:
             f = path.join(filepath, bots_list)
             log.info("Remove author %s <%s> from %s ...", github_user, github_email, f)
+            if unify_copilot_users:
+                log.info("Also unify copilot users to %s <%s> in %s ...", copilot_unified_name, copilot_unified_email, f)
+            copilot_user_added = False
             bot_data = csv_writer.read_from_csv(f)
 
             bot_data_new = []
@@ -254,7 +257,15 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
             for entry in bot_data:
                 # keep bot entry only if it should not be removed
                 if not is_github_noreply_author(entry[0], entry[1]):
-                    bot_data_new.append(entry)
+                    # unify copilot users if desired
+                    if unify_copilot_users and entry[0] in known_copilot_users_extended:
+                        if not copilot_user_added:
+                            entry[0] = copilot_unified_name
+                            entry[1] = copilot_unified_email
+                            copilot_user_added = True
+                            bot_data_new.append(entry)
+                    else:
+                        bot_data_new.append(entry)
                 else:
                     log.warn("Remove entry %s <%s> from bots list.", entry[0], entry[1])
 

--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -14,7 +14,7 @@
 #
 # Copyright 2015-2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 # Copyright 2020-2022 by Thomas Bock <bockthom@cs.uni-saarland.de>
-# Copyright 2025 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
+# Copyright 2025-2026 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 # All Rights Reserved.
 """
 This file is able to disambiguate authors after the extraction from the Codeface database was performed. A manually
@@ -52,6 +52,15 @@ from csv_writer import csv_writer
 
 
 ##
+# GLOBAL VARIABLES
+##
+
+# global variable containing all known copilot users and the name and mail adress copilot users will be assigned
+known_copilot_users = {"Copilot", "copilot-pull-request-reviewer[bot]", "copilot-swe-agentbot"}
+copilot_unified_name = "Copilot"
+copilot_unified_email = "copilot@example.com"
+
+##
 # RUN POSTPROCESSING
 ##
 
@@ -79,7 +88,7 @@ def perform_data_backup(results_path, results_path_backup):
                     copy(current_file, backup_file)
 
 
-def fix_github_browser_commits(data_path, issues_github_list, commits_list, authors_list, emails_list, bots_list):
+def fix_github_browser_commits(data_path, issues_github_list, commits_list, authors_list, emails_list, bots_list, unify_copilot_users=True):
     """
     Replace the author "GitHub <noreply@github.com>" in both commit and GitHub issue data by the correct author.
     The author "GitHub <noreply@github.com>" is automatically inserted as the committer of a commit that is made when
@@ -183,6 +192,11 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
             issue_data_new = []
 
             for event in issue_data:
+                # unify events to use a single copilot user for all events triggered by a known copilot user
+                if unify_copilot_users and event[9] in known_copilot_users:
+                    event[9] = copilot_unified_name
+                    event[10] = copilot_unified_email
+
                 # replace author if necessary
                 if is_github_noreply_author(event[9], event[10]) and event[8] == commit_added_event:
                     # extract commit hash from event info 1

--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -14,6 +14,7 @@
 #
 # Copyright 2015-2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 # Copyright 2020-2022 by Thomas Bock <bockthom@cs.uni-saarland.de>
+# Copyright 2025 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 # All Rights Reserved.
 """
 This file is able to disambiguate authors after the extraction from the Codeface database was performed. A manually
@@ -186,6 +187,7 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
                 if is_github_noreply_author(event[9], event[10]) and event[8] == commit_added_event:
                     # extract commit hash from event info 1
                     commit_hash = event[12]
+                    # extract author name from event info 2 while cutting excess '"'
                     name = event[13][1:-1]
                     # extract commit author from commit data, if available
                     if commit_hash in commit_hash_to_author:

--- a/author_postprocessing/author_postprocessing.py
+++ b/author_postprocessing/author_postprocessing.py
@@ -50,9 +50,11 @@ from codeface.dbmanager import DBManager
 
 from csv_writer import csv_writer
 
-from github_user_utils import known_copilot_users, copilot_unified_name, copilot_unified_email, \
+from github_user_utils.github_user_utils import known_copilot_users, copilot_unified_name, copilot_unified_email, \
                               is_github_noreply_author, github_user, github_email, \
-                              commit_added_event, mentioned_event, subscribed_event, generate_botname_variants
+                              commit_added_event, mentioned_event, subscribed_event, \
+                              assigned_event, unassigned_event, review_requested_event, \
+                              review_request_removed_event, generate_botname_variants, quot_m
 
 known_copilot_users_extended = generate_botname_variants(known_copilot_users)
 ##
@@ -173,6 +175,9 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
                 if unify_copilot_users and commit[5] in known_copilot_users_extended:
                     commit[5] = copilot_unified_name
                     commit[6] = copilot_unified_email
+                if unify_copilot_users and commit[2] in known_copilot_users_extended:
+                    commit[2] = copilot_unified_name
+                    commit[3] = copilot_unified_email
 
             csv_writer.write_to_csv(f, commit_data)
 
@@ -191,19 +196,20 @@ def fix_github_browser_commits(data_path, issues_github_list, commits_list, auth
             commit_hash_to_author = {commit[7]: commit[2:4] for commit in commit_data}
             author_name_to_data = {author[1]: author[1:3] for author in author_data_new}
             issue_data_new = []
-
             for event in issue_data:
                 # unify events to use a single copilot user for all events triggered by a known copilot user
                 if unify_copilot_users and event[9] in known_copilot_users_extended:
                     event[9] = copilot_unified_name
                     event[10] = copilot_unified_email
-                    if event[8] == commit_added_event and event[13][-1:1] in known_copilot_users_extended:
-                        # for commit added events, also unify the referenced author in event info 2 if it is a known copilot user
-                        event[13] = '"' + copilot_unified_name + '"'
-                    elif event[8] in (mentioned_event, subscribed_event) and event[12][-1:1] in known_copilot_users_extended:
-                        # for mentioned/subscribed events, also unify the referenced user in event info 1 and 2 if it is a known copilot user
-                        event[12] = '"' + copilot_unified_name + '"'
-                        event[13] = '"' + copilot_unified_email + '"'
+                if unify_copilot_users and event[8] == commit_added_event and event[13][1:-1] in known_copilot_users_extended:
+                    # for commit added events, also unify the referenced author in event info 2 if it is a known copilot user
+                    event[13] = quot_m + copilot_unified_name + quot_m
+                elif unify_copilot_users and event[8] in (mentioned_event, subscribed_event, assigned_event, unassigned_event,
+                                                          review_requested_event, review_request_removed_event) \
+                                         and event[12] in known_copilot_users_extended:
+                    # for mentioned/subscribed events, also unify the referenced user in event info 1 and 2 if it is a known copilot user
+                    event[12] = copilot_unified_name
+                    event[13] = quot_m + copilot_unified_email + quot_m
                 # replace author if necessary
                 if is_github_noreply_author(event[9], event[10]) and event[8] == commit_added_event:
                     # extract commit hash from event info 1
@@ -302,9 +308,6 @@ def run_postprocessing(conf, resdir, backup_data):
     bugs_jira_list = "bugs-jira.list"
     bots_list = "bots.list"
 
-    # When looking at elements originating from json lists, we need to consider quotation marks around the string
-    quot_m = "\""
-
     data_path = path.join(resdir, conf["project"], conf["tagging"])
 
     # Correctly replace author 'GitHub <noreply@github.com>' in the commit data and in "commit_added" events of the
@@ -395,8 +398,8 @@ def run_postprocessing(conf, resdir, backup_data):
                         issue_event[12] = person[1]
                         issue_event[13] = quot_m + person[2] + quot_m
                     # replace name in event info 2 if necessary
-                    if person[4] == issue_event[13]:
-                        issue_event[13] = person[1]
+                    if quot_m + person[4] + quot_m == issue_event[13]:
+                        issue_event[13] = quot_m + person[1] + quot_m
 
             csv_writer.write_to_csv(f, issue_data)
 
@@ -463,8 +466,12 @@ def run_postprocessing(conf, resdir, backup_data):
                     # the bot is already in the list, check if there are different predictions
                     stored_bot = bot_names_and_emails[(bot[0], bot[1])]
                     if stored_bot[2] != bot[2]:
+                        # if either of the predictions is agent, keep agent
+                        if (stored_bot[2] == "Agent" or bot[2] == "Agent"):
+                            stored_bot[2] = "Agent"
+                            bot_names_and_emails[(bot[0], bot[1])] = stored_bot
                         # if either of the predictions is bot, keep bot
-                        if (stored_bot[2] == "Bot" or bot[2] == "Bot"):
+                        elif (stored_bot[2] == "Bot" or bot[2] == "Bot"):
                             stored_bot[2] = "Bot"
                             bot_names_and_emails[(bot[0], bot[1])] = stored_bot
                         # otherwise, if either of the predictions is human, keep human

--- a/bot_processing/bot_processing.py
+++ b/bot_processing/bot_processing.py
@@ -222,6 +222,14 @@ def add_user_data(bot_data, user_data, known_bots_file, known_agents_file):
             bot_reduced["user"] = user_buffer[user[0]]
             bot_reduced["prediction"] = user[-1]
             bot_data_reduced.append(bot_reduced)
+        elif user[0] + "bot" in user_buffer.keys():
+            bot_reduced["user"] = user_buffer[user[0] + "bot"]
+            bot_reduced["prediction"] = user[-1]
+            bot_data_reduced.append(bot_reduced)
+        elif user[0] + "[bot]" in user_buffer.keys():
+            bot_reduced["user"] = user_buffer[user[0] + "[bot]"]
+            bot_reduced["prediction"] = user[-1]
+            bot_data_reduced.append(bot_reduced)
         else:
             log.warn("User '{}' in bot data does not occur in GitHub user data. Remove user...".format(user[0]))
 

--- a/bot_processing/bot_processing.py
+++ b/bot_processing/bot_processing.py
@@ -30,7 +30,7 @@ from codeface.cli import log
 from codeface.configuration import Configuration
 
 from csv_writer import csv_writer
-from github_user_utils import known_copilot_users, generate_botname_variants
+from github_user_utils.github_user_utils import known_copilot_users, generate_botname_variants
 
 def run():
     # get all needed paths and arguments for the method call.

--- a/bot_processing/bot_processing.py
+++ b/bot_processing/bot_processing.py
@@ -82,7 +82,7 @@ def load_bot_data(bot_file, header = True):
 
     # check if file exists and exit early if not
     if not os.path.exists(bot_file):
-        log.error("Bot file '{}' does not exist! Exiting early...".format(bot_file))
+        log.error("Bot/Agent file '{}' does not exist (can be empty)! Exiting early...".format(bot_file))
         sys.exit(-1)
 
     bot_data = csv_writer.read_from_csv(bot_file, delimiter=',')

--- a/github_user_utils/__init__.py
+++ b/github_user_utils/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/github_user_utils/github_user_utils.py
+++ b/github_user_utils/github_user_utils.py
@@ -52,3 +52,22 @@ def is_github_noreply_author(name, email):
     """
 
     return (name == github_user and (email == github_email or email == (github_user + "." + github_email)))
+
+def generate_botname_variants(botnames):
+    """
+    Helper function to generate variants of bot names, which are used in the list of
+    known bots and agents as well as during author postprocessing.
+
+    :param botnames: the list of bot names for which variants should be generated
+    :return: a set of bot name variants
+    """
+
+    botname_variants = set()
+    for botname in botnames:
+        botname_variants.add(botname)
+        if botname.endswith("[bot]"):
+            botname_variants.add(botname[:-5] + "bot")
+        elif botname.endswith("bot"):
+            botname_variants.add(botname[:-3] + "[bot]")
+
+    return botname_variants

--- a/github_user_utils/github_user_utils.py
+++ b/github_user_utils/github_user_utils.py
@@ -24,7 +24,7 @@ issue data extraction and post-processing, in particular for the processing of G
 ##
 
 # global variables containing all known copilot users and the name and mail adress copilot users will be assigned
-known_copilot_users = {"Copilot", "copilot-pull-request-reviewer[bot]", "copilot-swe-agentbot"}
+known_copilot_users = {"Copilot", "copilot-pull-request-reviewer[bot]", "copilot-swe-agent[bot]"}
 copilot_unified_name = "Copilot"
 copilot_unified_email = "copilot@example.com"
 
@@ -65,9 +65,7 @@ def generate_botname_variants(botnames):
     botname_variants = set()
     for botname in botnames:
         botname_variants.add(botname)
-        if botname.endswith("[bot]"):
-            botname_variants.add(botname[:-5] + "bot")
-        elif botname.endswith("bot"):
-            botname_variants.add(botname[:-3] + "[bot]")
+        botname = botname.replace("[", "").replace("]", "")
+        botname_variants.add(botname)
 
     return botname_variants

--- a/github_user_utils/github_user_utils.py
+++ b/github_user_utils/github_user_utils.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+# This file is part of codeface-extraction, which is free software: you
+# can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2026 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
+# All Rights Reserved.
+"""
+This file serves as a collection of global variables and utility functions, which are used throughout the 
+issue data extraction and post-processing, in particular for the processing of GitHub and Copilot user data.
+"""
+
+##
+# GLOBAL VARIABLES
+##
+
+# global variables containing all known copilot users and the name and mail adress copilot users will be assigned
+known_copilot_users = {"Copilot", "copilot-pull-request-reviewer[bot]", "copilot-swe-agentbot"}
+copilot_unified_name = "Copilot"
+copilot_unified_email = "copilot@example.com"
+
+## global variables for the GitHub author
+github_user = "GitHub"
+github_email = "noreply@github.com"
+commit_added_event = "commit_added"
+mentioned_event = "mentioned"
+subscribed_event = "subscribed"
+
+##
+# UTILITY FUNCTIONS
+##
+
+def is_github_noreply_author(name, email):
+    """
+    Helper function to check whether a (name, e-mail) pair belongs to the author "GitHub <noreply@github.com>".
+    There are two options in Codeface how this can happen:
+    (1) Username is "GitHub" and e-mail address is "noreply@github.com"
+    (2) Username is "GitHub" and e-mail address has been replaced by Codeface, resulting in "GitHub.noreply@github.com"
+
+    :param name: the name of the author to be checked
+    :param email: the email address of the author to be checked
+    :return: whether the given (name, email) pair belongs to the "GitHub <noreply@github.com>" author
+    """
+
+    return (name == github_user and (email == github_email or email == (github_user + "." + github_email)))

--- a/github_user_utils/github_user_utils.py
+++ b/github_user_utils/github_user_utils.py
@@ -34,6 +34,13 @@ github_email = "noreply@github.com"
 commit_added_event = "commit_added"
 mentioned_event = "mentioned"
 subscribed_event = "subscribed"
+assigned_event = "assigned"
+unassigned_event = "unassigned"
+review_requested_event = "review_requested"
+review_request_removed_event = "review_request_removed"
+
+# When looking at elements originating from json lists, we need to consider quotation marks around the string
+quot_m = "\""
 
 ##
 # UTILITY FUNCTIONS

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -77,15 +77,10 @@ def run():
     issues = load(__srcdir)
     # 2) re-format the issues
     reformat_issues(issues)
-    # create an empty dict for external connected events, meaning connected
-    # events that connect to an issue in another repository
-    external_connected_events = dict()
     # 3) merges all issue events into one list
-    # this step returns a dict containing all connected events that can be matched to the correct issues later
+    external_connected_events = dict()
     filtered_connected_events = merge_issue_events(issues, external_connected_events)
     # 4) re-format the eventsList of the issues
-    # this step also reconstructs the connections previously stored
-    # in 'external_connected_events' and 'filtered_connected_events'
     reformat_events(issues, filtered_connected_events, external_connected_events)
     # 5) update user data with Codeface database and dump username-to-name/e-mail list
     insert_user_data(issues, __conf, __resdir)
@@ -539,6 +534,8 @@ def merge_issue_events(issue_data, external_connected_events):
         issue["eventsList"] = sorted(issue["eventsList"], key=lambda k: k["created_at"])
 
     # filter out connected events which cannot be perfectly matched
+    # and populate external_connected_events dict
+    # because this happens in place, we do not need to return the external_connected_event dict later
     filtered_connected_events = dict(filter(lambda item: filter_connected_events(item[0], item[1], external_connected_events), connected_events.items()))
 
     # updates all the issues by the temporarily stored referenced_by events
@@ -547,6 +544,7 @@ def merge_issue_events(issue_data, external_connected_events):
             if issue["number"] == value["number"]:
                 issue["eventsList"] = issue["eventsList"] + value["eventsList"]
 
+    # return the filtered_connected_events dict for later reconstruction
     return filtered_connected_events
 
 

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -261,13 +261,17 @@ def reformat_issues(issue_data):
         if issue["relatedCommits"] is None:
             issue["relatedCommits"] = []
 
-        # if an issue has no reviewsList, an empty Listgets created
+        # if an issue has no reviewsList, an empty List gets created
         if issue["reviewsList"] is None:
             issue["reviewsList"] = []
 
         # if an issue has no relatedIssues, an empty List gets created
         if "relatedIssues" not in issue:
             issue["relatedIssues"] = []
+
+        # if an issue has no sub-issue list, an empty List gets created
+        if "subIssues" not in issue:
+            issue["subIssues"] = []
 
         # add "closed_at" information if not present yet
         if issue["closed_at"] is None:
@@ -737,9 +741,10 @@ def reformat_events(issue_data, filtered_connected_events, external_connected_ev
                     issue["eventsList"].append(resolution_event)
 
             elif event["event"] == "commented":
-                # "state_new" and "resolution" of the issue give the information about the state and the resolution of
+                # "state_new" of the issue gives the information about the state of
                 # the issue when the comment was written, because the eventsList is sorted by time
                 event["event_info_1"] = issue["state_new"]
+                # if event is a review comment, it can contain suggestions
                 if "contains_suggestion" in event:
                     event["event_info_2"] = event["contains_suggestion"]
                 else:

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -742,7 +742,10 @@ def reformat_events(issue_data, filtered_connected_events, external_connected_ev
                 # "state_new" and "resolution" of the issue give the information about the state and the resolution of
                 # the issue when the comment was written, because the eventsList is sorted by time
                 event["event_info_1"] = issue["state_new"]
-                event["event_info_2"] = issue["resolution"]
+                if "contains_suggestion" in event:
+                    event["event_info_2"] = event["contains_suggestion"]
+                else:
+                    event["event_info_2"] = False
 
             elif event["event"] == "referenced" and not event["commit"] is None:
                 # remove "referenced" events originating from commits

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -361,6 +361,7 @@ def merge_issue_events(issue_data):
             # it is a commit which was added to the pull request
             if rel_commit["type"] == "commitAddedToPullRequest":
                 rel_commit["event"] = "commit_added"
+                rel_commit["event_info_2"] = rel_commit["commit"]["author"]
 
             # if the related commit was mentioned in an issue comment:
             elif rel_commit["type"] == "commitMentionedInIssue":
@@ -745,6 +746,9 @@ def insert_user_data(issues, conf, resdir):
         for event in issue["eventsList"]:
             event["user"] = get_id_and_update_user(event["user"])
 
+            if event["event"] == "commit_added":
+                event["event_info_2"] = get_id_and_update_user(event["event_info_2"])
+
             # check database for the reference-target user if needed
             if event["ref_target"] != "":
                 event["ref_target"] = get_id_and_update_user(event["ref_target"])
@@ -757,6 +761,10 @@ def insert_user_data(issues, conf, resdir):
         # get event authors
         for event in issue["eventsList"]:
             event["user"] = get_user_from_id(event["user"])
+
+            # for commit_added events, save the commit's author's name in event_info_2
+            if event["event"] == "commit_added":
+                event["event_info_2"] = get_user_from_id(event["event_info_2"])["name"]
 
             # get the reference-target user if needed
             if event["ref_target"] != "":

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -18,7 +18,7 @@
 # Copyright 2018-2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
 # Copyright 2019 by Thomas Bock <bockthom@fim.uni-passau.de>
 # Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
-# Copyright 2025 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
+# Copyright 2025-2026 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 # All Rights Reserved.
 """
 This file is able to extract Github issue data from json files.
@@ -53,6 +53,9 @@ known_resolutions = {"unresolved", "fixed", "wontfix", "duplicate", "invalid", "
 
 # datetime format string
 datetime_format = "%Y-%m-%d %H:%M:%S"
+
+# Copilot username to be assigned in specific copilot events
+copilot_username = "Copilot"
 
 def run():
     # get all needed paths and arguments for the method call.
@@ -487,6 +490,12 @@ def merge_issue_events(issue_data, external_connected_events):
             # if event is a review request, we can update the ref target with the requested reviewer
             if event["event"] == "review_requested" or event["event"] == "review_request_removed":
                 event["ref_target"] = event["requestedReviewer"]
+
+            # if event is a specific copilot event, assign the copilot user data
+            if event["event"] == "copilot_work_started" or event["event"] == "copilot_work_finished":
+                event["user"]["name"] = None
+                event["user"]["username"] = copilot_username
+                event["user"]["email"] = ""
 
             # if event dismisses a review, we can determine the original state of the corresponding review
             if event["event"] == "review_dismissed":

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -41,6 +41,7 @@ from codeface.dbmanager import DBManager
 from dateutil import parser as dateparser
 
 from csv_writer import csv_writer
+from github_user_utils import copilot_unified_name
 
 # known types from JIRA and GitHub default labels
 known_types = {"bug", "improvement", "enhancement", "feature", "task", "test", "wish"}
@@ -54,8 +55,6 @@ known_resolutions = {"unresolved", "fixed", "wontfix", "duplicate", "invalid", "
 # datetime format string
 datetime_format = "%Y-%m-%d %H:%M:%S"
 
-# Copilot username to be assigned in specific copilot events
-copilot_username = "Copilot"
 
 def run():
     # get all needed paths and arguments for the method call.
@@ -494,7 +493,7 @@ def merge_issue_events(issue_data, external_connected_events):
             # if event is a specific copilot event, assign the copilot user data
             if event["event"] == "copilot_work_started" or event["event"] == "copilot_work_finished":
                 event["user"]["name"] = None
-                event["user"]["username"] = copilot_username
+                event["user"]["username"] = copilot_unified_name
                 event["user"]["email"] = ""
 
             # if event dismisses a review, we can determine the original state of the corresponding review

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -654,13 +654,16 @@ def reformat_events(issue_data):
             if event["event"] == "closed":
                 event["event"] = "state_updated"
                 event["event_info_1"] = "closed"  # new state
-                event["event_info_2"] = "open"  # old state
+                if event["commit"] is not None:
+                    event["event_info_2"] = event["commit"]["hash"]
+                else:
+                    event["event_info_2"] = event["state_reason"]
                 issue["state_new"] = "closed"
 
             elif event["event"] == "reopened":
                 event["event"] = "state_updated"
                 event["event_info_1"] = "open"  # new state
-                event["event_info_2"] = "closed"  # old state
+                event["event_info_2"] = event["state_reason"]
                 issue["state_new"] = "reopened"
 
             elif event["event"] == "labeled":

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -43,7 +43,7 @@ from dateutil import parser as dateparser
 from csv_writer import csv_writer
 
 # known types from JIRA and GitHub default labels
-known_types = {"bug", "improvement", "enhancement", "new feature", "task", "test", "wish"}
+known_types = {"bug", "improvement", "enhancement", "feature", "task", "test", "wish"}
 
 # known resolutions from JIRA and GitHub default labels
 known_resolutions = {"unresolved", "fixed", "wontfix", "duplicate", "invalid", "incomplete", "cannot reproduce",
@@ -243,7 +243,10 @@ def reformat_issues(issue_data):
     for issue in issue_data:
 
         # empty container for issue types
-        issue["type"] = []
+        if issue["type"] is None:
+            issue["type"] = []
+        else:
+            issue["type"] = [issue["type"]["name"].lower()]
 
         # empty container for issue resolutions
         issue["resolution"] = []

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -902,7 +902,7 @@ def print_to_disk(issues, results_folder):
                 json.dumps(issue["resolution"]),
                 issue["created_at"],
                 issue["closed_at"],
-                json.dumps([]),  # components
+                json.dumps([issue["subIssues"]]),  # components
                 event["event"],
                 event["user"]["name"],
                 event["user"]["email"],

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -79,13 +79,13 @@ def run():
     # 1) load the list of issues
     issues = load(__srcdir)
     # 2) re-format the issues
-    issues = reformat_issues(issues)
+    reformat_issues(issues)
     # 3) merges all issue events into one list
-    issues = merge_issue_events(issues)
+    merge_issue_events(issues)
     # 4) re-format the eventsList of the issues
-    issues = reformat_events(issues)
+    reformat_events(issues)
     # 5) update user data with Codeface database and dump username-to-name/e-mail list
-    issues = insert_user_data(issues, __conf, __resdir)
+    insert_user_data(issues, __conf, __resdir)
     # 6) dump result to disk
     print_to_disk(issues, __resdir)
 
@@ -284,7 +284,7 @@ def reformat_issues(issue_data):
         else:
             issue["type"].append("issue")
 
-    return issue_data
+    return
 
 
 def merge_issue_events(issue_data):
@@ -538,7 +538,7 @@ def merge_issue_events(issue_data):
             if issue["number"] == value["number"]:
                 issue["eventsList"] = issue["eventsList"] + value["eventsList"]
 
-    return issue_data
+    return
 
 
 def filter_connected_events(key, value):
@@ -747,7 +747,7 @@ def reformat_events(issue_data):
         for event_to_remove in events_to_remove:
             issue["eventsList"].remove(event_to_remove)
 
-    return issue_data
+    return
 
 
 def insert_user_data(issues, conf, resdir):
@@ -884,7 +884,7 @@ def insert_user_data(issues, conf, resdir):
     username_dump = os.path.join(resdir, "usernames.list")
     csv_writer.write_to_csv(username_dump, sorted(set(lines), key=lambda line: line[0]))
 
-    return issues
+    return
 
 
 def print_to_disk(issues, results_folder):

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -532,7 +532,7 @@ def merge_issue_events(issue_data, external_connected_events):
                     # if there is no connected event yet at this timestamp, create a new entry for this event
                     connected_info = dict()
                     connected_info["issues"] = [issue["number"]]
-                    connected_info["user"] = issue["user"]
+                    connected_info["user"] = event["user"]
                     connected_events[event["created_at"]] = connected_info
 
         # merge events, relatedCommits, relatedIssues and comment lists

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
 # Copyright 2019 by Thomas Bock <bockthom@fim.uni-passau.de>
 # Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
+# Copyright 2025 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 # All Rights Reserved.
 """
 This file is able to extract Github issue data from json files.

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -31,7 +31,6 @@ import os
 import sys
 import urllib
 from datetime import datetime, timedelta
-import math
 
 import operator
 from codeface.cli import log
@@ -234,7 +233,6 @@ def reformat_issues(issue_data):
     Re-arrange issue data structure.
 
     :param issue_data: the issue data to re-arrange
-    :return: the re-arranged issue data
     """
 
     log.devinfo("Re-arranging Github issues...")
@@ -299,7 +297,8 @@ def merge_issue_events(issue_data, external_connected_events):
     All issue events are merged together in the eventsList. This simplifies processing in later steps.
 
     :param issue_data: the issue data from which the events shall be merged
-    :return: the issue data with merged eventsList
+    :param external_connected_events: a dict to store connected events to external issues
+    :return: a filtered dict of connected events for future reconstruction
     """
 
     log.info("Merge issue events ...")
@@ -573,17 +572,17 @@ def filter_connected_events(key, value, external_connected_events):
     # if 2 connected events exist, matching them is trivial
     if num_issues == 2:
         return True
-    occurences = {x: value["issues"].count(x) for x in set(value["issues"])}
+    occurrences = {x: value["issues"].count(x) for x in set(value["issues"])}
     # otherwise, if it is an even number, check if it can be easily matched,
     # meaning that exactly half the events occur in the same issue
-    if num_issues % 2 == 0 and num_issues/2 in occurences.values():
+    if num_issues % 2 == 0 and num_issues/2 in occurrences.values():
         # duplicate issue list for matching the issues later
         value["multi_issues_copy"] = list(value["issues"])
         return True
     # if it is an odd number, check if it can be easily matched
     # meaning that exactly half (rounded up) the events occur in the same issue
-    if num_issues % 2 == 1 and (num_issues + 1)/2 in occurences.values():
-        for sub_key, sub_value in occurences.iteritems():
+    if num_issues % 2 == 1 and (num_issues + 1)/2 in occurrences.values():
+        for sub_key, sub_value in occurrences.iteritems():
             # then, assign one of them as an external connected event and proceed as in previous case
             if sub_value == (num_issues + 1)/2:
                 new_entry = dict()
@@ -603,7 +602,8 @@ def reformat_events(issue_data, filtered_connected_events, external_connected_ev
     Re-format event information dependent on the event type.
 
     :param issue_data: the data of all issues that shall be re-formatted
-    :return: the issue data with updated event information
+    :param filtered_connected_events: the dict of connected events which can be reconstructed
+    :param external_connected_events: the dict of connected events to external issues
     """
 
     log.info("Update event information ...")
@@ -643,9 +643,9 @@ def reformat_events(issue_data, filtered_connected_events, external_connected_ev
                         # and we only have 2 issues in the list, connect to the other issue
                         event["event_info_1"] = value["issues"][0] if value["issues"][1] == issue["number"] else value["issues"][1]
                     else:
-                        # and we have more than two issues, count each issue's occurences
-                        occurences = {x: value["issues"].count(x) for x in set(value["issues"])}
-                        if occurences[issue["number"]] == max(occurences.values()):
+                        # and we have more than two issues, count each issue's occurrences
+                        occurrences = {x: value["issues"].count(x) for x in set(value["issues"])}
+                        if occurrences[issue["number"]] == max(occurrences.values()):
                             # if our issue is the most common one, that means it is the common denominator
                             # for all connected events at this time
                             # so this event connects to any other issue
@@ -655,7 +655,7 @@ def reformat_events(issue_data, filtered_connected_events, external_connected_ev
                             event["event_info_1"] = number
                         else:
                             # otherwise, connect this event to the common denominator
-                            event["event_info_1"] = max(occurences, key=occurences.get)
+                            event["event_info_1"] = max(occurrences, key=occurrences.get)
 
     # as the user dictionary is created, start re-formating the event information of all issues
     for issue in issue_data:
@@ -785,7 +785,6 @@ def insert_user_data(issues, conf, resdir):
     :param issues: the issues to retrieve user data from
     :param conf: the project configuration
     :param resdir: the directory in which the username-to-user-list should be dumped
-    :return: the updated issue data
     """
 
     log.info("Syncing users with ID service...")

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -41,7 +41,7 @@ from codeface.dbmanager import DBManager
 from dateutil import parser as dateparser
 
 from csv_writer import csv_writer
-from github_user_utils import copilot_unified_name
+from github_user_utils.github_user_utils import copilot_unified_name
 
 # known types from JIRA and GitHub default labels
 known_types = {"bug", "improvement", "enhancement", "feature", "task", "test", "wish"}
@@ -754,9 +754,9 @@ def reformat_events(issue_data, filtered_connected_events, external_connected_ev
                 event["event_info_1"] = issue["state_new"]
                 # if event is a review comment, it can contain suggestions
                 if "contains_suggestion" in event:
-                    event["event_info_2"] = event["contains_suggestion"]
+                    event["event_info_2"] = str(event["contains_suggestion"])
                 else:
-                    event["event_info_2"] = False
+                    event["event_info_2"] = str(False)
 
             elif event["event"] == "referenced" and not event["commit"] is None:
                 # remove "referenced" events originating from commits
@@ -934,7 +934,7 @@ def print_to_disk(issues, results_folder):
                 json.dumps(issue["resolution"]),
                 issue["created_at"],
                 issue["closed_at"],
-                json.dumps([issue["subIssues"]]),  # components
+                json.dumps(issue["subIssues"]),  # components
                 event["event"],
                 event["user"]["name"],
                 event["user"]["email"],

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -534,6 +534,10 @@ def merge_issue_events(issue_data, external_connected_events):
                     connected_info["user"] = event["user"]
                     connected_events[event["created_at"]] = connected_info
 
+            # if event is a locked event, save the lock reason in event_info_1
+            if event["event"] == "locked":
+                event["event_info_1"] = event["lock_reason"]
+
         # merge events, relatedCommits, relatedIssues and comment lists
         issue["eventsList"] = issue["commentsList"] + issue["eventsList"] + issue["relatedIssues"] + issue[
             "relatedCommits"] + issue["reviewsList"]

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -266,11 +266,11 @@ def reformat_issues(issue_data):
             issue["reviewsList"] = []
 
         # if an issue has no relatedIssues, an empty List gets created
-        if "relatedIssues" not in issue:
+        if issue["relatedIssues"] is None:
             issue["relatedIssues"] = []
 
         # if an issue has no sub-issue list, an empty List gets created
-        if "subIssues" not in issue:
+        if issue["subIssues"] is None:
             issue["subIssues"] = []
 
         # add "closed_at" information if not present yet

--- a/issue_processing/issue_processing.py
+++ b/issue_processing/issue_processing.py
@@ -508,7 +508,7 @@ def merge_issue_events(issue_data, external_connected_events):
                 event["user"] = event["assigner"]
 
             # if event is merged event, save the hash of the merge commit in event_info_1
-            if event["event"] == "merged":
+            if event["event"] == "merged" and not event["commit"] is None:
                 event["event_info_1"] = event["commit"]["hash"]
 
             # if event is connected event, create or add to a matching dict entry by matching timestamps, for later reconstruction

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -300,9 +300,12 @@ def parse_xml(issue_data, persons, skip_history, referenced_bys):
         link = issue_x.getElementsByTagName("link")[0]
         issue["url"] = link.firstChild.data
 
-        type = issue_x.getElementsByTagName("type")[0]
-        issue["type"] = type.firstChild.data
-        issue["type_list"] = ["issue", str(type.firstChild.data.lower())]
+        type = issue_x.getElementsByTagName("type")[0].firstChild.data
+        # rename 'new feature' type to 'feature' to be in line with the github original issue type
+        if type == "New Feature":
+            type = "Feature"
+        issue["type"] = type
+        issue["type_list"] = ["issue", str(type.lower())]
 
         status = issue_x.getElementsByTagName("status")[0]
         issue["state"] = status.firstChild.data

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
 # Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
 # Copyright 2023 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
+# Copyright 2025 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 # All Rights Reserved.
 """
 This file is able to extract Jira issue data from xml files.
@@ -125,7 +126,7 @@ def run():
                 referenced_issue["history"].append(referenced_by)
 
     # 5) update user data with Codeface database
-    processed_issues = insert_user_data(processed_issues, __conf)
+    insert_user_data(processed_issues, __conf)
     # 6) dump result to disk
     print_to_disk(processed_issues, __resdir)
     # # 7) export for Gephi
@@ -689,7 +690,7 @@ def insert_user_data(issues, conf):
                 event["event_info_2"] = assigned_user["email"]
 
     log.debug("number of issues after insert_user_data: '{}'".format(len(issues)))
-    return issues
+    return
 
 
 def print_to_disk(issues, results_folder):

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -464,21 +464,18 @@ def load_issues_via_api(issues, persons, url, referenced_bys):
             for change in changelog.histories:
 
                 # default values for state and resolution
-                old_state, new_state, old_resolution, new_resolution = "open", "open", "unresolved", "unresolved"
+                new_state, old_resolution, new_resolution = "open", "unresolved", "unresolved"
 
                 # all changes in the issue changelog are checked if they contain a useful information
                 for item in change.items:
 
                     # state_updated event gets created and added to the issue history
                     if item.field == "status":
-                        if item.fromString is not None:
-                            old_state = item.fromString.lower()
                         if item.toString is not None:
                             new_state = item.toString.lower()
                         history = dict()
                         history["event"] = "state_updated"
                         history["event_info_1"] = new_state
-                        history["event_info_2"] = old_state
                         if hasattr(change, "author"):
                             user = create_user(change.author.displayName, change.author.name, "")
                         else:

--- a/issue_processing/jira_issue_processing.py
+++ b/issue_processing/jira_issue_processing.py
@@ -18,7 +18,7 @@
 # Copyright 2018-2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
 # Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
 # Copyright 2023 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
-# Copyright 2025 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
+# Copyright 2025-2026 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 # All Rights Reserved.
 """
 This file is able to extract Jira issue data from xml files.
@@ -476,6 +476,7 @@ def load_issues_via_api(issues, persons, url, referenced_bys):
                         history = dict()
                         history["event"] = "state_updated"
                         history["event_info_1"] = new_state
+                        history["event_info_2"] = ""
                         if hasattr(change, "author"):
                             user = create_user(change.author.displayName, change.author.name, "")
                         else:


### PR DESCRIPTION
This pr adresses issue #52 

Fixes this issue by adding the correct author to field 'event_info_2' in the issue data. This allows for reconstruction of the commit's author during author postprocessing, if the user that envoked the event is the 'GitHub' user.

Since parts of the changes take place in functions relying on codeface, testing all the changes is currently not possible.